### PR TITLE
dynamically determine python flags for cfg

### DIFF
--- a/python27-sys/Cargo.toml
+++ b/python27-sys/Cargo.toml
@@ -21,21 +21,11 @@ exclude = [
 [dependencies]
 libc = "*"
 
-[build-dependencies]
-pkg-config = "0.3"
+# [build-dependencies]
+# pkg-config = "0.3"
 
-[features]
-# Features correspond to possible settings used when compiling python.
-# It's probably a misuse to use cargo features for this;
-# ideally we'd auto-detect these in the build script.
-default = ["Py_USING_UNICODE", "Py_UNICODE_WIDE", "WITH_THREAD"]
-
-Py_USING_UNICODE = []
-Py_UNICODE_WIDE = [ "Py_USING_UNICODE" ]
-
-Py_DEBUG = [ "Py_TRACE_REFS" ]
-Py_TRACE_REFS = [ "Py_REF_DEBUG" ]
-Py_REF_DEBUG = []
-COUNT_ALLOCS = []
-WITH_THREAD = []
-
+# TODO: depends on trunk pkg-config for now because we 
+# require 14c4b9, can revert this when alex bumps the 
+# crate release 
+[build-dependencies.pkg-config]
+git = "https://github.com/alexcrichton/pkg-config-rs.git"

--- a/python27-sys/build.rs
+++ b/python27-sys/build.rs
@@ -1,6 +1,115 @@
 extern crate pkg_config;
 
-fn main() {
-    pkg_config::find_library("python-2.7").unwrap();
+use std::process::Command;
+use std::collections::HashMap;
+
+const CFG_KEY: &'static str = "py_sys_config";
+
+// A list of python interpreter compile-time preprocessor defines that 
+// we will pick up and pass to rustc via --cfg=py_sys_config={varname};
+// this allows using them conditional cfg attributes in the .rs files, so
+//
+// #[cfg(py_sys_config="{varname}"]
+//
+// is the equivalent of #ifdef {varname} name in C.
+//
+// see Misc/SpecialBuilds.txt in the python source for what these mean.
+//
+// (hrm, this is sort of re-implementing what distutils does, except 
+// by passing command line args instead of referring to a python.h)
+static SYSCONFIG_FLAGS: [&'static str; 7] = [
+    "Py_USING_UNICODE",
+    "Py_UNICODE_WIDE",
+    "WITH_THREAD",
+    "Py_DEBUG",
+    "Py_REF_DEBUG",
+    "Py_TRACE_REFS",
+    "COUNT_ALLOCS",
+];
+
+static SYSCONFIG_VALUES: [&'static str; 1] = [
+    // cfg doesn't support flags with values, just bools - so flags 
+    // below are translated into bools as {varname}_{val} 
+    //
+    // for example, Py_UNICODE_SIZE_2 or Py_UNICODE_SIZE_4
+    "Py_UNICODE_SIZE"
+];
+
+/// Examine python's compile flags to pass to cfg by launching
+/// the interpreter and printing variables of interest from 
+/// sysconfig.get_config_vars.
+fn get_config_vars() -> Result<HashMap<String, String>, String>  {
+    let exec_prefix = pkg_config::Config::get_variable(
+        "python-2.7", "exec_prefix").unwrap();
+
+    // assume path to the pkg_config python interpreter is 
+    // {exec_prefix}/bin/python - this might not hold for all platforms, but
+    // the .pc doesn't give us anything else to go on
+    let python_path = format!("{}/bin/python", exec_prefix);
+
+    let mut script = "import sysconfig; \
+config = sysconfig.get_config_vars();".to_owned();
+
+    for k in SYSCONFIG_FLAGS.iter().chain(SYSCONFIG_VALUES.iter()) {
+        script.push_str(&format!("print(config.get('{}', 0))", k));
+        script.push_str(";");
+    }
+
+    let mut cmd = Command::new(python_path);
+    cmd.arg("-c").arg(script);
+
+    let out = try!(cmd.output().map_err(|e| {
+        format!("failed to run python interpreter `{:?}`: {}", cmd, e)
+    }));
+
+    if !out.status.success() {
+        let stderr = String::from_utf8(out.stderr).unwrap();
+        let mut msg = format!("python script failed with stderr:\n\n");
+        msg.push_str(&stderr);
+        return Err(msg);
+    }
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+
+    let var_map : HashMap<String, String> = 
+        SYSCONFIG_FLAGS.iter().chain(SYSCONFIG_VALUES.iter()).zip(stdout.split('\n'))
+            .map(|(&k, v)| (k.to_owned(), v.to_owned()))
+            .collect();
+
+    if var_map.len() != SYSCONFIG_VALUES.len() + SYSCONFIG_FLAGS.len() {
+        return Err(
+            "python stdout len didn't return expected number of lines".to_string());
+    }
+
+    return Ok(var_map);
 }
 
+fn cfg_line_for_var(key: &str, val: &str) -> Option<String> {
+    if SYSCONFIG_VALUES.iter().find(|x| **x == key).is_some() {
+        // is a value; suffix the key name with the value
+        Some(format!("cargo:rustc-cfg={}=\"{}_{}\"", CFG_KEY, key, val))
+    } else if val != "0" {
+        // is a flag that isn't zero
+        Some(format!("cargo:rustc-cfg={}=\"{}\"", CFG_KEY, key))
+    } else {
+        // is a flag that is zero
+        None
+    }
+}
+
+fn main() {
+    // By default, use pkg_config to locate a python 2.7 to use.
+    //
+    // TODO - allow the user to specify a python via environment variables
+    // (PYTHONHOME?) - necessary for systems with no pkg-config, or for
+    // compiling against pythons other than the pkg-config one.
+
+    pkg_config::find_library("python-2.7").unwrap();
+    let config_map = get_config_vars().unwrap();
+    for (key, val) in &config_map {
+        match cfg_line_for_var(key, val) {
+            Some(line) => println!("{}", line),
+            None => ()
+        }
+    }
+}

--- a/python27-sys/src/bytearrayobject.rs
+++ b/python27-sys/src/bytearrayobject.rs
@@ -5,9 +5,9 @@ use object::*;
 /*#[repr(C)]
 #[deriving(Copy)]
 struct PyByteArrayObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,

--- a/python27-sys/src/ceval.rs
+++ b/python27-sys/src/ceval.rs
@@ -51,7 +51,7 @@ extern "C" {
      -> c_int;
 }
 
-#[cfg(feature = "WITH_THREAD")]
+#[cfg(py_sys_config="WITH_THREAD")]
 extern "C" {
     pub fn PyEval_ThreadsInitialized() -> c_int;
     pub fn PyEval_InitThreads();

--- a/python27-sys/src/classobject.rs
+++ b/python27-sys/src/classobject.rs
@@ -5,9 +5,9 @@ use object::*;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyClassObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,
@@ -23,9 +23,9 @@ pub struct PyClassObject {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyInstanceObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,
@@ -37,9 +37,9 @@ pub struct PyInstanceObject {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyMethodObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,

--- a/python27-sys/src/complexobject.rs
+++ b/python27-sys/src/complexobject.rs
@@ -22,9 +22,9 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyComplexObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,

--- a/python27-sys/src/floatobject.rs
+++ b/python27-sys/src/floatobject.rs
@@ -5,9 +5,9 @@ use object::*;
 #[repr(C)]
 #[derive(Copy, Clone)]
 struct PyFloatObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,

--- a/python27-sys/src/intobject.rs
+++ b/python27-sys/src/intobject.rs
@@ -5,9 +5,9 @@ use object::*;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyIntObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,
@@ -33,7 +33,7 @@ extern "C" {
     pub fn PyInt_FromString(str: *mut c_char,
                             pend: *mut *mut c_char,
                             base: c_int) -> *mut PyObject;
-    #[cfg(feature="Py_USING_UNICODE")]
+    #[cfg(py_sys_config="Py_USING_UNICODE")]
     pub fn PyInt_FromUnicode(u: *mut ::unicodeobject::Py_UNICODE, length: Py_ssize_t,
                              base: c_int) -> *mut PyObject;
     pub fn PyInt_FromLong(ival: c_long) -> *mut PyObject;

--- a/python27-sys/src/lib.rs
+++ b/python27-sys/src/lib.rs
@@ -7,7 +7,7 @@ pub use pymem::*;
 pub use object::*;
 pub use objimpl::*;
 pub use pydebug::*;
-#[cfg(feature="Py_USING_UNICODE")]
+#[cfg(py_sys_config="Py_USING_UNICODE")]
 pub use unicodeobject::*;
 pub use intobject::*;
 pub use boolobject::*;
@@ -53,7 +53,7 @@ mod pymem;
 mod object;
 mod objimpl;
 mod pydebug;
-#[cfg(feature="Py_USING_UNICODE")]
+#[cfg(py_sys_config="Py_USING_UNICODE")]
 mod unicodeobject; // TODO: incomplete
 mod intobject;
 mod boolobject;
@@ -117,11 +117,11 @@ mod eval;
 pub mod structmember;
 
 
-#[cfg(not(feature="Py_USING_UNICODE"))]
+#[cfg(not(py_sys_config="Py_USING_UNICODE"))]
 #[inline(always)]
 pub fn PyUnicode_Check(op : *mut PyObject) -> c_int { 0 }
 
-#[cfg(not(feature="Py_USING_UNICODE"))]
+#[cfg(not(py_sys_config="Py_USING_UNICODE"))]
 #[inline(always)]
 pub fn PyUnicode_CheckExact(op : *mut PyObject) -> c_int { 0 }
 

--- a/python27-sys/src/listobject.rs
+++ b/python27-sys/src/listobject.rs
@@ -5,9 +5,9 @@ use object::*;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyListObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,

--- a/python27-sys/src/longobject.rs
+++ b/python27-sys/src/longobject.rs
@@ -32,7 +32,7 @@ extern "C" {
     pub fn PyLong_FromString(str: *mut c_char,
                              pend: *mut *mut c_char,
                              base: c_int) -> *mut PyObject;
-    #[cfg(feature="Py_USING_UNICODE")]
+    #[cfg(py_sys_config="Py_USING_UNICODE")]
     pub fn PyLong_FromUnicode(u: *mut ::unicodeobject::Py_UNICODE, length: Py_ssize_t,
                               base: c_int) -> *mut PyObject;
     pub fn PyLong_FromVoidPtr(p: *mut c_void) -> *mut PyObject;

--- a/python27-sys/src/memoryobject.rs
+++ b/python27-sys/src/memoryobject.rs
@@ -34,9 +34,9 @@ extern "C" {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyMemoryViewObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,

--- a/python27-sys/src/methodobject.rs
+++ b/python27-sys/src/methodobject.rs
@@ -79,9 +79,9 @@ pub struct PyMethodChain {
 #[repr(C)]
 #[derive(Copy)]
 struct PyCFunctionObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,

--- a/python27-sys/src/modsupport.rs
+++ b/python27-sys/src/modsupport.rs
@@ -34,26 +34,26 @@ extern "C" {
                                       value: *const c_char)
      -> c_int;
     
-    #[cfg(all(target_pointer_width = "64", not(feature = "Py_TRACE_REFS")))]
+    #[cfg(all(target_pointer_width = "64", not(py_sys_config = "Py_TRACE_REFS")))]
     fn Py_InitModule4_64(name: *const c_char,
                              methods: *mut PyMethodDef,
                              doc: *const c_char, _self: *mut PyObject,
                              apiver: c_int) -> *mut PyObject;
 
-    #[cfg(all(target_pointer_width = "64", feature = "Py_TRACE_REFS"))]
+    #[cfg(all(target_pointer_width = "64", py_sys_config = "Py_TRACE_REFS"))]
     fn Py_InitModule4TraceRefs_64(name: *const c_char,
                                   methods: *mut PyMethodDef,
                                   doc: *const c_char, _self: *mut PyObject,
                                   apiver: c_int) -> *mut PyObject;
 
 
-    #[cfg(all(not(target_pointer_width = "64"), not(feature = "Py_TRACE_REFS")))]
+    #[cfg(all(not(target_pointer_width = "64"), not(py_sys_config = "Py_TRACE_REFS")))]
     pub fn Py_InitModule4(name: *const c_char,
                              methods: *mut PyMethodDef,
                              doc: *const c_char, _self: *mut PyObject,
                              apiver: c_int) -> *mut PyObject;
 
-    #[cfg(all(not(target_pointer_width = "64"), feature = "Py_TRACE_REFS"))]
+    #[cfg(all(not(target_pointer_width = "64"), py_sys_config = "Py_TRACE_REFS"))]
     fn Py_InitModule4TraceRefs(name: *const c_char,
                                   methods: *mut PyMethodDef,
                                   doc: *const c_char, _self: *mut PyObject,
@@ -62,7 +62,7 @@ extern "C" {
 
 pub const PYTHON_API_VERSION : c_int = 1013;
 
-#[cfg(all(target_pointer_width = "64", not(feature = "Py_TRACE_REFS")))]
+#[cfg(all(target_pointer_width = "64", not(py_sys_config = "Py_TRACE_REFS")))]
 #[inline(always)]
 pub unsafe fn Py_InitModule4(name: *const c_char,
                       methods: *mut PyMethodDef,
@@ -71,7 +71,7 @@ pub unsafe fn Py_InitModule4(name: *const c_char,
     Py_InitModule4_64(name, methods, doc, _self, apiver)
 }
 
-#[cfg(all(target_pointer_width = "64", feature = "Py_TRACE_REFS"))]
+#[cfg(all(target_pointer_width = "64", py_sys_config = "Py_TRACE_REFS"))]
 #[inline(always)]
 pub unsafe fn Py_InitModule4(name: *const c_char,
                       methods: *mut PyMethodDef,
@@ -80,7 +80,7 @@ pub unsafe fn Py_InitModule4(name: *const c_char,
     Py_InitModule4TraceRefs_64(name, methods, doc, _self, apiver)
 }
 
-#[cfg(all(not(target_pointer_width = "64"), feature = "Py_TRACE_REFS"))]
+#[cfg(all(not(target_pointer_width = "64"), py_sys_config = "Py_TRACE_REFS"))]
 #[inline(always)]
 pub unsafe fn Py_InitModule4(name: *const c_char,
                       methods: *mut PyMethodDef,

--- a/python27-sys/src/object.rs
+++ b/python27-sys/src/object.rs
@@ -6,9 +6,9 @@ use methodobject::PyMethodDef;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,
@@ -17,9 +17,9 @@ pub struct PyObject {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyVarObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,
@@ -485,7 +485,7 @@ pub unsafe fn PyObject_Bytes(o: *mut PyObject) -> *mut PyObject {
 }
 
 extern "C" {
-    #[cfg(feature="Py_USING_UNICODE")]
+    #[cfg(py_sys_config="Py_USING_UNICODE")]
     pub fn PyObject_Unicode(o: *mut PyObject) -> *mut PyObject;
     
     pub fn PyObject_Compare(arg1: *mut PyObject, arg2: *mut PyObject)
@@ -638,7 +638,7 @@ pub unsafe fn PyType_FastSubclass(t : *mut PyTypeObject, f : c_long) -> c_int {
 // Reference counting macros.
 #[inline(always)]
 pub unsafe fn Py_INCREF(op : *mut PyObject) {
-    if cfg!(feature="Py_REF_DEBUG") {
+    if cfg!(py_sys_config="Py_REF_DEBUG") {
         Py_IncRef(op)
     } else {
         (*op).ob_refcnt += 1
@@ -647,7 +647,7 @@ pub unsafe fn Py_INCREF(op : *mut PyObject) {
 
 #[inline(always)]
 pub unsafe fn Py_DECREF(op: *mut PyObject) {
-    if cfg!(feature="Py_REF_DEBUG") || cfg!(feature="COUNT_ALLOCS") {
+    if cfg!(py_sys_config="Py_REF_DEBUG") || cfg!(py_sys_config="COUNT_ALLOCS") {
         Py_DecRef(op)
     } else {
         (*op).ob_refcnt -= 1;

--- a/python27-sys/src/pyerrors.rs
+++ b/python27-sys/src/pyerrors.rs
@@ -3,7 +3,7 @@ use pyport::Py_ssize_t;
 use object::*;
 use classobject::*;
 use stringobject::PyString_AS_STRING;
-#[cfg(feature="Py_USING_UNICODE")]
+#[cfg(py_sys_config="Py_USING_UNICODE")]
 use unicodeobject::Py_UNICODE;
 
 extern "C" {
@@ -137,7 +137,7 @@ extern "C" {
      -> *mut PyObject;
 }
 
-#[cfg(feature="Py_USING_UNICODE")]
+#[cfg(py_sys_config="Py_USING_UNICODE")]
 extern "C" {
     pub fn PyUnicodeDecodeError_Create(arg1: *const c_char,
                                        arg2: *const c_char,

--- a/python27-sys/src/pystate.rs
+++ b/python27-sys/src/pystate.rs
@@ -76,7 +76,7 @@ extern "C" {
     pub fn _PyThreadState_Init(arg1: *mut PyThreadState);
     pub fn PyThreadState_Clear(arg1: *mut PyThreadState);
     pub fn PyThreadState_Delete(arg1: *mut PyThreadState);
-    #[cfg(feature="WITH_THREAD")]
+    #[cfg(py_sys_config="WITH_THREAD")]
     pub fn PyThreadState_DeleteCurrent();
     pub fn PyThreadState_Get() -> *mut PyThreadState;
     pub fn PyThreadState_Swap(arg1: *mut PyThreadState) -> *mut PyThreadState;
@@ -95,13 +95,13 @@ extern "C" {
     pub fn PyThreadState_Next(arg1: *mut PyThreadState) -> *mut PyThreadState;
 }
 
-#[cfg(feature="Py_DEBUG")]
+#[cfg(py_sys_config="Py_DEBUG")]
 #[inline(always)]
 pub unsafe fn PyThreadState_GET() -> *mut PyThreadState {
     PyThreadState_Get()
 }
 
-#[cfg(not(feature="Py_DEBUG"))]
+#[cfg(not(py_sys_config="Py_DEBUG"))]
 #[inline(always)]
 pub unsafe fn PyThreadState_GET() -> *mut PyThreadState {
     _PyThreadState_Current

--- a/python27-sys/src/stringobject.rs
+++ b/python27-sys/src/stringobject.rs
@@ -5,9 +5,9 @@ use object::*;
 #[repr(C)]
 #[allow(missing_copy_implementations)]
 struct PyStringObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,

--- a/python27-sys/src/tupleobject.rs
+++ b/python27-sys/src/tupleobject.rs
@@ -5,9 +5,9 @@ use object::*;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyTupleObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,

--- a/python27-sys/src/unicodeobject.rs
+++ b/python27-sys/src/unicodeobject.rs
@@ -2,24 +2,24 @@ use libc::{c_char, c_int, c_long, c_double, wchar_t};
 use pyport::Py_ssize_t;
 use object::*;
 
-#[cfg(feature="Py_UNICODE_WIDE")]
+#[cfg(py_sys_config="Py_UNICODE_WIDE")]
 pub const Py_UNICODE_SIZE : Py_ssize_t = 4;
-#[cfg(not(feature="Py_UNICODE_WIDE"))]
+#[cfg(not(py_sys_config="Py_UNICODE_WIDE"))]
 pub const Py_UNICODE_SIZE : Py_ssize_t = 2;
 
 pub type Py_UCS4 = u32;
 
-#[cfg(feature="Py_UNICODE_WIDE")]
+#[cfg(py_sys_config="Py_UNICODE_WIDE")]
 pub type Py_UNICODE = u32;
-#[cfg(not(feature="Py_UNICODE_WIDE"))]
+#[cfg(not(py_sys_config="Py_UNICODE_WIDE"))]
 pub type Py_UNICODE = u16;
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyUnicodeObject {
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_next: *mut PyObject,
-    #[cfg(feature="Py_TRACE_REFS")]
+    #[cfg(py_sys_config="Py_TRACE_REFS")]
     pub _ob_prev: *mut PyObject,
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,
@@ -68,7 +68,7 @@ pub const Py_UNICODE_REPLACEMENT_CHARACTER : Py_UNICODE = 0xFFFD;
 
 
 #[allow(dead_code)]
-#[cfg(feature="Py_UNICODE_WIDE")]
+#[cfg(py_sys_config="Py_UNICODE_WIDE")]
 extern "C" {
     fn PyUnicodeUCS4_FromUnicode(u: *const Py_UNICODE, size: Py_ssize_t)
      -> *mut PyObject;
@@ -312,7 +312,7 @@ extern "C" {
 }
 
 #[allow(dead_code)]
-#[cfg(not(feature="Py_UNICODE_WIDE"))]
+#[cfg(not(py_sys_config="Py_UNICODE_WIDE"))]
 extern "C" {
     fn PyUnicodeUCS2_FromUnicode(u: *const Py_UNICODE, size: Py_ssize_t)
      -> *mut PyObject;
@@ -555,26 +555,26 @@ extern "C" {
     fn _PyUnicodeUCS2_IsAlpha(ch: Py_UNICODE) -> c_int;
 }
 
-#[inline(always)]
-#[cfg(feature="Py_UNICODE_WIDE")]
+/*#[inline(always)]
+#[cfg(py_sys_config="Py_UNICODE_WIDE")]
 pub unsafe fn PyUnicode_FromStringAndSize(u: *const c_char, size: Py_ssize_t) -> *mut PyObject {
     PyUnicodeUCS4_FromStringAndSize(u, size)
-}
+}*/
 
 #[inline(always)]
-#[cfg(not(feature="Py_UNICODE_WIDE"))]
+#[cfg(not(py_sys_config="Py_UNICODE_WIDE"))]
 pub unsafe fn PyUnicode_FromStringAndSize(u: *const c_char, size: Py_ssize_t) -> *mut PyObject {
     PyUnicodeUCS2_FromStringAndSize(u, size)
 }
 
 #[inline(always)]
-#[cfg(feature="Py_UNICODE_WIDE")]
+#[cfg(py_sys_config="Py_UNICODE_WIDE")]
 pub unsafe fn PyUnicode_AsUTF8String(u: *mut PyObject) -> *mut PyObject {
     PyUnicodeUCS4_AsUTF8String(u)
 }
 
 #[inline(always)]
-#[cfg(not(feature="Py_UNICODE_WIDE"))]
+#[cfg(not(py_sys_config="Py_UNICODE_WIDE"))]
 pub unsafe fn PyUnicode_AsUTF8String(u: *mut PyObject) -> *mut PyObject {
     PyUnicodeUCS2_AsUTF8String(u)
 }


### PR DESCRIPTION
* in build.rs, call the python interpreter located by pkgconfig
and use sysconfig to determine the flags it was built with.
* pass these flags to the build via --cfg
* refactor existing references to features to refer to these
instead

background - I'm trying to get this to build on os x, and apparently the homebrew python 2.7 is a utf-16 build (?!) so seemed logical to get this working (another pr coming soon for some blips in string conversion under utf-16).

this would need to be replicated across to python 3 also; would be keen to hear your thoughts on how best to share code between the two build.rs scripts for the two ffis.
