### PR TITLE
can build with only a major python 3 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,9 @@ optional = true
 [features]
 # Maybe one day python 3 should be the default. But not this day.
 default = ["python27-sys"]
+
+# Optional features to support explicitly specifying python minor version.
+# If you don't care which minor version, just specify python3-sys as a 
+# feature.
+python-3-5 = ["python3-sys/python-3-5"]
+python-3-4 = ["python3-sys/python-3-4"]

--- a/python27-sys/Cargo.toml
+++ b/python27-sys/Cargo.toml
@@ -41,5 +41,5 @@ git = "https://github.com/alexcrichton/pkg-config-rs.git"
 #
 # Similarly functionality is duplicated in python3-sys/Cargo.toml 
 # where supporting multiple 3.x's is more important.
-default = ["python_2_7"]
-python_2_7 = []
+default = ["python-2-7"]
+python-2-7 = []

--- a/python3-sys/Cargo.toml
+++ b/python3-sys/Cargo.toml
@@ -35,6 +35,11 @@ git = "https://github.com/alexcrichton/pkg-config-rs.git"
 [features]
 # This is examined by ./build.rs to determine which python version 
 # to try to bind to.
-default = ["python_3_4"]
-python_3_4 = []
-python_3_5 = []
+default = ["python-3"]
+
+# Bind to any python 3.x.
+python-3 = []
+
+# Or, bind to a particular minor version.
+python-3-4 = []
+python-3-5 = []


### PR DESCRIPTION
Resolves #6.

For python3-sys:

Try to get 'python3' from pkg-config, then fall back to finding any python 3 in the PATH:
`cargo build`

Try to get python3.5 from pkg-config, then fall back to finding a python 3.5 in the PATH:
`cargo build --features python-3-5`

For rust-cpython:

Build against any python 3:
`cargo build --features python3-sys --no-default-features`

Build against a python 3.5
`cargo build --features "python3-sys python-3-5" --no-default-features


