### PR TITLE
windows support for build scripts

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,16 +23,18 @@ fn main() {
         }
     };
 
-    for f in flags.split(",") {
-        // write out flags as --cfg so that the same #cfg blocks can be used
-        // in rust-cpython as in the -sys libs
-        let key_and_val: Vec<&str> = f.split("=").collect();
-        let key = key_and_val[0];
-        let val = key_and_val[1];
-        if key.starts_with("FLAG") {
-            println!("cargo:rustc-cfg={}=\"{}\"", CFG_KEY, &key[5..])
-        } else {
-            println!("cargo:rustc-cfg={}=\"{}_{}\"", CFG_KEY, &key[4..], val);
+    if flags.len() > 0 {
+        for f in flags.split(",") {
+            // write out flags as --cfg so that the same #cfg blocks can be used
+            // in rust-cpython as in the -sys libs
+            let key_and_val: Vec<&str> = f.split("=").collect();
+            let key = key_and_val[0];
+            let val = key_and_val[1];
+            if key.starts_with("FLAG") {
+                println!("cargo:rustc-cfg={}=\"{}\"", CFG_KEY, &key[5..])
+            } else {
+                println!("cargo:rustc-cfg={}=\"{}_{}\"", CFG_KEY, &key[4..], val);
+            }
         }
     }
 }

--- a/python27-sys/build.rs
+++ b/python27-sys/build.rs
@@ -169,12 +169,11 @@ fn run_python_script(script: &str) -> Result<String, String> {
 #[cfg(not(target_os="macos"))]
 #[cfg(not(target_os="windows"))]
 fn get_rustc_link_lib(version: &PythonVersion, enable_shared: bool) -> Result<String, String> {
+    let dotted_version = format!("{}.{}", version.major, version.minor.unwrap());
     if enable_shared {
-        Ok(format!("cargo:rustc-link-lib=python{}.{}", version.major,
-            version.minor))
+        Ok(format!("cargo:rustc-link-lib=python{}", dotted_version))
     } else {
-        Ok(format!("cargo:rustc-link-lib=static=python{}.{}", version.major,
-            version.minor))
+        Ok(format!("cargo:rustc-link-lib=static=python{}", dotted_version))
     }
 }
 

--- a/python3-sys/build.rs
+++ b/python3-sys/build.rs
@@ -169,12 +169,11 @@ fn run_python_script(script: &str) -> Result<String, String> {
 #[cfg(not(target_os="macos"))]
 #[cfg(not(target_os="windows"))]
 fn get_rustc_link_lib(version: &PythonVersion, enable_shared: bool) -> Result<String, String> {
+    let dotted_version = format!("{}.{}", version.major, version.minor.unwrap());
     if enable_shared {
-        Ok(format!("cargo:rustc-link-lib=python{}.{}", version.major,
-            version.minor))
+        Ok(format!("cargo:rustc-link-lib=python{}", dotted_version));
     } else {
-        Ok(format!("cargo:rustc-link-lib=static=python{}.{}", version.major,
-            version.minor))
+        Ok(format!("cargo:rustc-link-lib=static=python{}", dotted_version));
     }
 }
 


### PR DESCRIPTION
can build the ffis for python27-sys, python3-sys; now failing with

src\objects\num.rs:127:9: 134:10 error: the trait `conversion::ToPyObject<'_>` i
s not implemented for the type `i64` [E0277]
src\objects\num.rs:127         impl <'p> ToPyObject<'p> for $rust_type {
src\objects\num.rs:128             type ObjectType = <$larger_type as ToPyObject
<'p>>::ObjectType;
src\objects\num.rs:129
src\objects\num.rs:130             #[inline]
src\objects\num.rs:131             fn to_py_object(&self, py: Python<'p>) -> <$l
arger_type as ToPyObject<'p>>::ObjectType {
src\objects\num.rs:132                 (*self as $larger_type).to_py_object(py)
                       ...
src\objects\num.rs:125:1: 147:3 note: in expansion of int_fits_larger_int!
src\objects\num.rs:171:1: 171:34 note: expansion site
src\objects\num.rs:127:9: 134:10 error: the trait `conversion::ToPyObject<'_>` i
s not implemented for the type `i64` [E0277]
src\objects\num.rs:127         impl <'p> ToPyObject<'p> for $rust_type {
src\objects\num.rs:128             type ObjectType = <$larger_type as ToPyObject
<'p>>::ObjectType;
src\objects\num.rs:129
src\objects\num.rs:130             #[inline]
src\objects\num.rs:131             fn to_py_object(&self, py: Python<'p>) -> <$l
arger_type as ToPyObject<'p>>::ObjectType {
src\objects\num.rs:132                 (*self as $larger_type).to_py_object(py)
                       ...
src\objects\num.rs:125:1: 147:3 note: in expansion of int_fits_larger_int!
src\objects\num.rs:171:1: 171:34 note: expansion site
error: aborting due to 2 previous errors
Could not compile `cpython`.

