### PR TITLE
Add tests for list.rs. Still missing tests for extract.

### DIFF
--- a/src/objects/list.rs
+++ b/src/objects/list.rs
@@ -160,3 +160,86 @@ impl <'python, 'source, 'prepared, T> ExtractPyObject<'python, 'source, 'prepare
     }
 }
 
+#[cfg(test)]
+mod test {
+    use std;
+    use python::{Python, PythonObject};
+    use conversion::ToPyObject;
+    use objects::PyList;
+
+    #[test]
+    fn test_len() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = vec![1,2,3,4];
+        let list = v.to_py_object(py).into_object().cast_into::<PyList>().unwrap();
+        assert_eq!(4, list.len());
+    }
+
+    #[test]
+    fn test_get_item() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = vec![2, 3, 5, 7];
+        let list = v.to_py_object(py).into_object().cast_into::<PyList>().unwrap();
+        assert_eq!(2, list.get_item(0).extract::<i32>().unwrap());
+        assert_eq!(3, list.get_item(1).extract::<i32>().unwrap());
+        assert_eq!(5, list.get_item(2).extract::<i32>().unwrap());
+        assert_eq!(7, list.get_item(3).extract::<i32>().unwrap());
+    }
+
+    #[test]
+    fn test_set_item() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = vec![2, 3, 5, 7];
+        let list = v.to_py_object(py).into_object().cast_into::<PyList>().unwrap();
+        let val = 42i32.to_py_object(py).into_object();
+        assert_eq!(2, list.get_item(0).extract::<i32>().unwrap());
+        list.set_item(0, val);
+        assert_eq!(42, list.get_item(0).extract::<i32>().unwrap());
+    }
+
+    #[test]
+    fn test_insert_item() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = vec![2, 3, 5, 7];
+        let list = v.to_py_object(py).into_object().cast_into::<PyList>().unwrap();
+        let val = 42i32.to_py_object(py).into_object();
+        assert_eq!(4, list.len());
+        assert_eq!(2, list.get_item(0).extract::<i32>().unwrap());
+        list.insert_item(0, val);
+        assert_eq!(5, list.len());
+        assert_eq!(42, list.get_item(0).extract::<i32>().unwrap());
+        assert_eq!(2, list.get_item(1).extract::<i32>().unwrap());
+    }
+
+    #[test]
+    fn test_iter() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = vec![2, 3, 5, 7];
+        let list = v.to_py_object(py).into_object().cast_into::<PyList>().unwrap();
+        let mut idx = 0;
+        for el in list {
+            assert_eq!(v[idx], el.extract::<i32>().unwrap());
+            idx += 1;
+        }
+        assert_eq!(idx, v.len());
+    }
+
+    #[test]
+    fn test_into_iter() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = vec![2, 3, 5, 7];
+        let list = v.to_py_object(py).into_object().cast_into::<PyList>().unwrap();
+        let mut idx = 0;
+        for el in list.into_iter() {
+            assert_eq!(v[idx], el.extract::<i32>().unwrap());
+            idx += 1;
+        }
+        assert_eq!(idx, v.len());
+    }
+}


### PR DESCRIPTION
This PR adds coverage for the list module.

I tried to also put in code to test extraction into vectors, but the following fails to compile:

```rust
    #[test]                                                                     
    fn test_extract() {                                                         
        let gil = Python::acquire_gil();                                        
        let py = gil.python();                                                  
        let v = vec![2, 3, 5, 7];                                               
        let list = v.to_py_object(py).into_object().cast_into::<PyList>().unwrap();
        let v2 = list.into_object().extract::<Vec<i32>>().unwrap();             
        assert_eq!(v, v2);                                                      
    }      
```

The error is:

```
$ cargo test
   Compiling cpython v0.0.4 (file:///home/ehiggs/src/download/rust-cpython)
src/objects/list.rs:251:37: 251:58 error: the requirement `for<'s>  : 's` is not satisfied (`expected bound lifetime parameter 's, found concrete lifetime`) [E0279]
src/objects/list.rs:251         let v2 = list.into_object().extract::<Vec<i32>>().unwrap();
                          
```

I was on IRC and some users suggested relaxing the bound constraints on extract so they are only over `'p` (instead of `for<'s, 'p>`) but I couldn't get it to work.