### PR TITLE
Add support for the Sequence protocol

### DIFF
--- a/src/objects/list.rs
+++ b/src/objects/list.rs
@@ -23,7 +23,7 @@ use ffi::{self, Py_ssize_t};
 use conversion::{ToPyObject, ExtractPyObject};
 
 /// Represents a Python `list`.
-pub struct PyList<'p>(PyObject<'p>);
+pub struct PyList<'p>(pub PyObject<'p>);
 
 pyobject_newtype!(PyList, PyList_Check, PyList_Type);
 

--- a/src/objects/list.rs
+++ b/src/objects/list.rs
@@ -17,13 +17,13 @@
 // DEALINGS IN THE SOFTWARE.
 
 use python::{Python, PythonObject, ToPythonPointer};
-use err::{self, PyResult};
+use err::{self, PyErr, PyResult};
 use super::object::PyObject;
 use ffi::{self, Py_ssize_t};
 use conversion::{ToPyObject, ExtractPyObject};
 
 /// Represents a Python `list`.
-pub struct PyList<'p>(pub PyObject<'p>);
+pub struct PyList<'p>(PyObject<'p>);
 
 pyobject_newtype!(PyList, PyList_Check, PyList_Type);
 
@@ -39,6 +39,21 @@ impl <'p> PyList<'p> {
             t
         }
     }
+
+    /// Construct a list from an existing object.
+    #[inline]
+    pub fn from_object(obj: PyObject<'p>) -> PyResult<'p, PyList> {
+        let py = obj.python();
+        let ptr = obj.as_ptr();
+        unsafe {
+            if ffi::PyList_Check(ptr) != 0{
+                Ok(PyList(obj))
+            } else {
+                Err(PyErr::fetch(py))
+            }
+        }
+    }
+
 
     /// Gets the length of the list.
     #[inline]

--- a/src/objects/list.rs
+++ b/src/objects/list.rs
@@ -40,21 +40,6 @@ impl <'p> PyList<'p> {
         }
     }
 
-    /// Construct a list from an existing object.
-    #[inline]
-    pub fn from_object(obj: PyObject<'p>) -> PyResult<'p, PyList> {
-        let py = obj.python();
-        let ptr = obj.as_ptr();
-        unsafe {
-            if ffi::PyList_Check(ptr) != 0{
-                Ok(PyList(obj))
-            } else {
-                Err(PyErr::fetch(py))
-            }
-        }
-    }
-
-
     /// Gets the length of the list.
     #[inline]
     pub fn len(&self) -> usize {

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -38,6 +38,7 @@ pub use self::num::PyInt;
 #[cfg(feature="python3-sys")]
 pub use self::num::PyLong as PyInt;
 pub use self::num::{PyLong, PyFloat};
+pub use self::sequence::PySequence;
 
 /// Identity conversion: allows using existing `PyObject` instances where
 /// `T: ToPyObject` is expected.
@@ -184,6 +185,7 @@ mod boolobject;
 mod tuple;
 mod list;
 mod num;
+mod sequence;
 pub mod exc;
 
 #[cfg(feature="python27-sys")]

--- a/src/objects/sequence.rs
+++ b/src/objects/sequence.rs
@@ -28,21 +28,15 @@ pub struct PySequence<'p>(PyObject<'p>);
 pyobject_newtype!(PySequence, PySequence_Check);
 
 impl <'p> PySequence<'p> {
-    /// Returns the number of objects in sequence.
+    /// Returns the number of objects in sequence. This is equivalent to Python `size` or `length`.
     #[inline]
-    pub fn size(&self) -> PyResult<'p, usize> {
+    pub fn len(&self) -> PyResult<'p, isize> {
         let v = unsafe { ffi::PySequence_Size(self.as_ptr()) };
         if v == -1 {
             Err(PyErr::fetch(self.python()))
         } else {
-            Ok(v as usize)
+            Ok(v as isize)
         }
-    }
-
-    /// Returns the number of objects in sequence. Same as size but included for completeness.
-    #[inline]
-    pub fn length(&self) -> PyResult<'p, usize> {
-        self.size()
     }
 
     /// Return the concatenation of o1 and o2. Equivalent to python `o1 + o2`
@@ -57,8 +51,9 @@ impl <'p> PySequence<'p> {
 
     /// Return the result of repeating sequence object o count times.
     /// Equivalent to python `o * count`
+    /// NB: Python accepts negative counts; it returns an empty Sequence.
     #[inline]
-    pub fn repeat(&self, count: usize) -> PyResult<'p, PySequence> {
+    pub fn repeat(&self, count: isize) -> PyResult<'p, PySequence> {
         let seq = try!(unsafe {
             let py = self.python();
             result_from_owned_ptr(py, ffi::PySequence_Repeat(self.as_ptr(), count as Py_ssize_t))
@@ -78,8 +73,9 @@ impl <'p> PySequence<'p> {
 
     /// Return the result of repeating sequence object o count times.
     /// Equivalent to python `o *= count`
+    /// NB: Python accepts negative counts; it empties the Sequence.
     #[inline]
-    pub fn in_place_repeat(&self, count: usize) -> PyResult<'p, PySequence> {
+    pub fn in_place_repeat(&self, count: isize) -> PyResult<'p, PySequence> {
         let seq = try!(unsafe {
             let py = self.python();
             result_from_owned_ptr(py,
@@ -90,18 +86,19 @@ impl <'p> PySequence<'p> {
 
     /// Return the ith element of the Sequence. Equivalent to python `o[index]`
     #[inline]
-    pub fn get_item(&self, index: usize) -> PyObject<'p> {
-        assert!(index < self.length().unwrap());
+    pub fn get_item(&self, index: isize) -> PyObject<'p> {
+        assert!(index < self.len().unwrap());
         unsafe {
             let py = self.python();
-            PyObject::from_borrowed_ptr(py, ffi::PySequence_GetItem(self.as_ptr(), index as Py_ssize_t))
+            PyObject::from_owned_ptr(py,
+                ffi::PySequence_GetItem(self.as_ptr(), index as Py_ssize_t))
         }
     }
 
     /// Return the slice of sequence object o between begin and end.
     /// This is the equivalent of the Python expression `o[begin:end]`
     #[inline]
-    pub fn get_slice(&self, begin : usize, end : usize) -> PyResult<'p, PySequence> {
+    pub fn get_slice(&self, begin : isize, end : isize) -> PyResult<'p, PySequence> {
         let slice = try!(unsafe {
             let py = self.python();
             result_from_owned_ptr(py,
@@ -113,7 +110,7 @@ impl <'p> PySequence<'p> {
     /// Assign object v to the ith element of o.
     /// Equivalent to Python statement `o[i] = v`
     #[inline]
-    pub fn set_item(&self, i: usize, v: &PyObject<'p>) -> PyResult<'p, ()> {
+    pub fn set_item(&self, i: isize, v: &PyObject<'p>) -> PyResult<'p, ()> {
         let v = unsafe {
             ffi::PySequence_SetItem(self.as_ptr(), i as Py_ssize_t, v.as_ptr())
         };
@@ -127,7 +124,7 @@ impl <'p> PySequence<'p> {
     /// Delete the ith element of object o.
     /// Python statement `del o[i]`
     #[inline]
-    pub fn del_item(&self, i: usize) -> PyResult<'p, ()> {
+    pub fn del_item(&self, i: isize) -> PyResult<'p, ()> {
         let v = unsafe { ffi::PySequence_DelItem(self.as_ptr(), i as Py_ssize_t) };
         if v == -1 {
             Err(PyErr::fetch(self.python()))
@@ -139,7 +136,7 @@ impl <'p> PySequence<'p> {
     /// Assign the sequence object v to the slice in sequence object o from i1 to i2.
     /// This is the equivalent of the Python statement `o[i1:i2] = v`
     #[inline]
-    pub fn set_slice(&self, i1: usize, i2: usize, v: &PyObject<'p>) -> PyResult<'p, ()> {
+    pub fn set_slice(&self, i1: isize, i2: isize, v: &PyObject<'p>) -> PyResult<'p, ()> {
         let v = unsafe {
             ffi::PySequence_SetSlice(self.as_ptr(), i1 as Py_ssize_t, i2 as Py_ssize_t, v.as_ptr())
         };
@@ -153,8 +150,10 @@ impl <'p> PySequence<'p> {
     /// Delete the slice in sequence object o from i1 to i2.
     /// equivalent of the Python statement `del o[i1:i2]`
     #[inline]
-    pub fn del_slice(&self, i1: i64, i2: i64) -> PyResult<'p, ()> {
-        let v = unsafe { ffi::PySequence_DelSlice(self.as_ptr(), i1, i2) };
+    pub fn del_slice(&self, i1: isize, i2: isize) -> PyResult<'p, ()> {
+        let v = unsafe { 
+            ffi::PySequence_DelSlice(self.as_ptr(), i1 as Py_ssize_t, i2 as Py_ssize_t) 
+        };
         if v == -1 {
             Err(PyErr::fetch(self.python()))
         } else {
@@ -220,7 +219,7 @@ impl <'p> PySequence<'p> {
 
 pub struct PySequenceIterator<'p> {
     sequence : PySequence<'p>,
-    index : usize
+    index : isize
 }
 
 impl <'p> IntoIterator for PySequence<'p> {
@@ -248,9 +247,9 @@ impl <'p> Iterator for PySequenceIterator<'p> {
     #[inline]
     fn next(&mut self) -> Option<PyObject<'p>> {
         // can't report any errors in underlying size check so we panic.
-        let len = self.sequence.length().unwrap();
+        let len = self.sequence.len().unwrap();
         if self.index < len {
-            let item = self.sequence.get_item(self.index) ;
+            let item = self.sequence.get_item(self.index);
             self.index += 1;
             Some(item)
         } else {
@@ -287,8 +286,7 @@ mod test {
         let py = gil.python();
         let v : Vec<i32> = vec![];
         let seq = v.to_py_object(py).into_object().cast_into::<PySequence>().unwrap();
-        assert_eq!(0, seq.length().unwrap());
-        assert_eq!(0, seq.size().unwrap());
+        assert_eq!(0, seq.len().unwrap());
 
         let needle = 7i32.to_py_object(py).into_object();
         assert_eq!(false, seq.contains(&needle).unwrap());
@@ -300,8 +298,7 @@ mod test {
         let py = gil.python();
         let v : Vec<i32> = vec![1, 1, 2, 3, 5, 8];
         let seq = v.to_py_object(py).into_object().cast_into::<PySequence>().unwrap();
-        assert_eq!(6, seq.length().unwrap());
-        assert_eq!(6, seq.size().unwrap());
+        assert_eq!(6, seq.len().unwrap());
 
         let bad_needle = 7i32.to_py_object(py).into_object();
         assert_eq!(false, seq.contains(&bad_needle).unwrap());
@@ -325,6 +322,11 @@ mod test {
         assert_eq!(3, seq.get_item(3).extract::<i32>().unwrap());
         assert_eq!(5, seq.get_item(4).extract::<i32>().unwrap());
         assert_eq!(8, seq.get_item(5).extract::<i32>().unwrap());
+        assert_eq!(8, seq.get_item(-1).extract::<i32>().unwrap());
+        assert_eq!(5, seq.get_item(-2).extract::<i32>().unwrap());
+        assert_eq!(3, seq.get_item(-3).extract::<i32>().unwrap());
+        assert_eq!(2, seq.get_item(-4).extract::<i32>().unwrap());
+        assert_eq!(1, seq.get_item(-5).extract::<i32>().unwrap());
         //assert!(seq.get_item(5).extract::<i32>().is_err()); // panics.
     }
 
@@ -351,7 +353,7 @@ mod test {
         assert!(seq.del_item(0).is_ok());
         assert_eq!(8, seq.get_item(0).extract::<i32>().unwrap());
         assert!(seq.del_item(0).is_ok());
-        assert_eq!(0, seq.length().unwrap());
+        assert_eq!(0, seq.len().unwrap());
         assert!(seq.del_item(0).is_err());
     }
 
@@ -432,7 +434,7 @@ mod test {
         let v : Vec<i32> = vec![1, 2, 3];
         let seq = v.to_py_object(py).into_object().cast_into::<PySequence>().unwrap();
         let concat_seq = seq.concat(&seq).unwrap();
-        assert_eq!(6, concat_seq.length().unwrap());
+        assert_eq!(6, concat_seq.len().unwrap());
         //let concat_v : Vec<i32> = vec![1, 2, 3, 1, 2, 3];
         //assert_eq!(concat_v, concat_seq.into_object().extract::<Vec<i32>>().unwrap());
     }
@@ -444,7 +446,7 @@ mod test {
         let v = "string";
         let seq = v.to_py_object(py).into_object().cast_into::<PySequence>().unwrap();
         let concat_seq = seq.concat(&seq).unwrap();
-        assert_eq!(12, concat_seq.length().unwrap());
+        assert_eq!(12, concat_seq.len().unwrap());
         //let concat_v = "stringstring";
         //assert_eq!(concat_v, concat_seq.into_object().extract::<String>().unwrap());
     }
@@ -456,7 +458,7 @@ mod test {
         let v = vec!["foo", "bar"];
         let seq = v.to_py_object(py).into_object().cast_into::<PySequence>().unwrap();
         let repeat_seq = seq.repeat(3).unwrap();
-        assert_eq!(6, repeat_seq.length().unwrap());
+        assert_eq!(6, repeat_seq.len().unwrap());
         //let repeated = vec!["foo", "bar", "foo", "bar", "foo", "bar"];
         //assert_eq!(repeated, repeat_seq.into_object().extract::<Vec<String>>().unwrap());
     }

--- a/src/objects/sequence.rs
+++ b/src/objects/sequence.rs
@@ -1,0 +1,364 @@
+// Copyright (c) 2015 Daniel Grunwald
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use std::mem;
+use ffi;
+use python::{PythonObject, ToPythonPointer};
+use objects::{PyObject, PyList, PyTuple};
+use ffi::Py_ssize_t;
+use err::{PyErr, PyResult, result_from_owned_ptr};
+
+pub struct PySequence<'p>(PyObject<'p>);
+
+pyobject_newtype!(PySequence, PySequence_Check);
+
+impl <'p> PySequence<'p> {
+    /// Construct a Sequence from an existing object.
+    #[inline]
+    pub fn from_object(obj: PyObject<'p>) -> PyResult<'p, PySequence> {
+        let py = obj.python();
+        let ptr = obj.as_ptr();
+        unsafe {
+            if ffi::PySequence_Check(ptr) != 0{
+                Ok(PySequence(obj))
+            } else {
+                Err(PyErr::fetch(py))
+            }
+        }
+    }
+
+    #[inline]
+    pub fn size(&self) -> PyResult<'p, usize> {
+        let v = unsafe { ffi::PySequence_Size(self.as_ptr()) };
+        if v == -1 {
+            Err(PyErr::fetch(self.python()))
+        } else {
+            Ok(v as usize)
+        }
+    }
+
+    #[inline]
+    pub fn length(&self) -> usize {
+        let v = unsafe { ffi::PySequence_Length(self.as_ptr()) };
+        if v == -1 {
+            panic!("Received an unexpected error finding the length of a PySequence")
+        }
+        v as usize
+    }
+
+    #[inline]
+    pub fn concat(&self, other: &PySequence<'p>) -> PyResult<'p, PySequence> {
+        let seq = try!(unsafe {
+            let py = self.python();
+            result_from_owned_ptr(py, ffi::PySequence_Concat(self.as_ptr(), other.as_ptr()))
+        });
+        Ok(PySequence(seq))
+    }
+
+    #[inline]
+    pub fn repeat(&self, count: usize) -> PyResult<'p, PySequence> {
+        let seq = try!(unsafe {
+            let py = self.python();
+            result_from_owned_ptr(py, ffi::PySequence_Repeat(self.as_ptr(), count as Py_ssize_t))
+        });
+        Ok(PySequence(seq))
+    }
+
+    #[inline]
+    pub fn in_place_concat(&self, other: &PySequence<'p>) -> PyResult<'p, PySequence> {
+        let seq = try!(unsafe {
+            let py = self.python();
+            result_from_owned_ptr(py, ffi::PySequence_InPlaceConcat(self.as_ptr(), other.as_ptr()))
+        });
+        Ok(PySequence(seq))
+    }
+
+    #[inline]
+    pub fn in_place_repeat(&self, count: usize) -> PyResult<'p, PySequence> {
+        let seq = try!(unsafe {
+            let py = self.python();
+            result_from_owned_ptr(py, 
+                ffi::PySequence_InPlaceRepeat(self.as_ptr(), count as Py_ssize_t))
+        });
+        Ok(PySequence(seq))
+    }
+
+    #[inline]
+    pub fn get_item(&self, index: usize) -> PyObject<'p> {
+        assert!(index < self.length());
+        unsafe {
+            let py = self.python();
+            PyObject::from_borrowed_ptr(py, ffi::PySequence_GetItem(self.as_ptr(), index as Py_ssize_t))
+        }
+    }
+
+    #[inline]
+    pub fn get_slice(&self, index: usize) -> PyResult<'p, PySequence> {
+        let slice = try!(unsafe {
+            let py = self.python();
+            result_from_owned_ptr(py, 
+                ffi::PySequence_GetItem(self.as_ptr(), index as Py_ssize_t))
+        });
+        Ok(PySequence(slice))
+    }
+
+    #[inline]
+    pub fn set_item(&self, i: usize, v: &PyObject<'p>) -> PyResult<'p, ()> {
+        let v = unsafe { 
+            ffi::PySequence_SetItem(self.as_ptr(), i as Py_ssize_t, v.as_ptr()) 
+        };
+        if v == -1 {
+            Err(PyErr::fetch(self.python()))
+        } else{ 
+            Ok(())
+        }
+    }
+
+    #[inline]
+    pub fn del_item(&self, i: usize) -> PyResult<'p, ()> {
+        let v = unsafe { ffi::PySequence_DelItem(self.as_ptr(), i as Py_ssize_t) };
+        if v == -1 {
+            Err(PyErr::fetch(self.python()))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    pub fn set_slice(&self, i1: usize, i2: usize, v: &PyObject<'p>) -> PyResult<'p, ()> {
+        let v = unsafe { 
+            ffi::PySequence_SetSlice(self.as_ptr(), i1 as Py_ssize_t, i2 as Py_ssize_t, v.as_ptr()) 
+        };
+        if v == -1 {
+            Err(PyErr::fetch(self.python()))
+        } else{ 
+            Ok(())
+        }
+    }
+
+    #[inline]
+    pub fn del_slice(&self, i1: i64, i2: i64) -> PyResult<'p, ()> {
+        let v = unsafe { ffi::PySequence_DelSlice(self.as_ptr(), i1, i2) };
+        if v == -1 {
+            Err(PyErr::fetch(self.python()))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    pub fn count(&self, v: &PyObject<'p>) -> PyResult<'p, usize> {
+        let v = unsafe { ffi::PySequence_Count(self.as_ptr(), v.as_ptr()) };
+        if v == -1 {
+            Err(PyErr::fetch(self.python()))
+        } else {
+            Ok(v as usize)
+        }
+    }
+
+    #[inline]
+    pub fn contains(&self, v: &PyObject<'p>) -> PyResult<'p, bool> {
+        let v = unsafe { ffi::PySequence_Contains(self.as_ptr(), v.as_ptr()) };
+        match v {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(PyErr::fetch(self.python()))
+        }
+    }
+
+    #[inline]
+    pub fn index(&self, v: &PyObject<'p>) -> PyResult<'p, usize> {
+        let v = unsafe { ffi::PySequence_Index(self.as_ptr(), v.as_ptr()) };
+        if v == -1 {
+            Err(PyErr::fetch(self.python()))
+        } else {
+            Ok(v as usize)
+        }
+    }
+
+    #[inline]
+    pub fn list(&self) -> PyResult<'p, PyList> {
+        let v = try!(unsafe { 
+            let py = self.python();
+            result_from_owned_ptr(py, ffi::PySequence_List(self.as_ptr()))
+        });
+        PyList::from_object(v)
+    }
+
+    #[inline]
+    pub fn tuple(&self) -> PyResult<'p, PyTuple> {
+        let v = try!(unsafe { 
+            let py = self.python();
+            result_from_owned_ptr(py, ffi::PySequence_Tuple(self.as_ptr()))
+        });
+        PyTuple::from_object(v)
+    }
+}
+
+pub struct PySequenceIterator<'p> {
+    sequence : PySequence<'p>,
+    index : usize
+}
+
+impl <'p> IntoIterator for PySequence<'p> {
+    type Item = PyObject<'p>;
+    type IntoIter = PySequenceIterator<'p>;
+
+    fn into_iter(self) -> PySequenceIterator<'p> {
+        PySequenceIterator{ sequence: self, index: 0 }
+    }
+}
+
+impl <'a, 'p> IntoIterator for &'a PySequence<'p> {
+    type Item = PyObject<'p>;
+    type IntoIter = PySequenceIterator<'p>;
+
+    #[inline]
+    fn into_iter(self) -> PySequenceIterator<'p> {
+        PySequenceIterator{ sequence: self.clone(), index: 0 }
+    }
+}
+
+impl <'p> Iterator for PySequenceIterator<'p> {
+    type Item = PyObject<'p>;
+
+    #[inline]
+    fn next(&mut self) -> Option<PyObject<'p>> {
+        // can't report any errors in underlying size check so we panic.
+        let len = self.sequence.length();
+        if self.index < len {
+            let item = self.sequence.get_item(self.index) ;
+            self.index += 1;
+            Some(item)
+        } else { 
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std;
+    use python::{Python, PythonObject};
+    use conversion::ToPyObject;
+    use objects::PySequence;
+
+    #[test]
+    fn test_numbers_are_not_sequences() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = 42i32;
+        match PySequence::from_object(v.to_py_object(py).into_object()) {
+            Ok(_) => panic!(), // We shouldn't be able to make a sequence from a number!
+            Err(_) => assert!(true)
+        };
+    }
+
+    #[test]
+    fn test_strings_are_sequences() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = "London Calling";
+        match PySequence::from_object(v.to_py_object(py).into_object()) {
+            Ok(_) => assert!(true),
+            Err(_) => panic!()
+        };
+    }
+    #[test]
+    fn test_seq_empty() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v : Vec<i32> = vec![];
+        let seq = PySequence::from_object(v.to_py_object(py).into_object()).unwrap();
+        assert_eq!(0, seq.length());
+        assert_eq!(0, seq.size().unwrap());
+
+        let needle = 7i32.to_py_object(py).into_object();
+        assert_eq!(false, seq.contains(&needle).unwrap());
+    }
+
+    #[test]
+    fn test_seq_filled() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v : Vec<i32> = vec![1, 1, 2, 3, 5, 8];
+        let seq = PySequence::from_object(v.to_py_object(py).into_object()).unwrap();
+        assert_eq!(6, seq.length());
+        assert_eq!(6, seq.size().unwrap());
+
+        let bad_needle = 7i32.to_py_object(py).into_object();
+        assert_eq!(false, seq.contains(&bad_needle).unwrap());
+
+        let good_needle = 8i32.to_py_object(py).into_object();
+        assert_eq!(true, seq.contains(&good_needle).unwrap());
+
+        let type_coerced_needle = 8f32.to_py_object(py).into_object();
+        assert_eq!(true, seq.contains(&type_coerced_needle).unwrap());
+    }
+
+    #[test]
+    fn test_seq_strings() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = vec!["It", "was", "the", "worst", "of", "times"];
+        let seq = PySequence::from_object(v.to_py_object(py).into_object()).unwrap();
+
+        let bad_needle = "blurst".to_py_object(py).into_object();
+        assert_eq!(false, seq.contains(&bad_needle).unwrap());
+
+        let good_needle = "worst".to_py_object(py).into_object();
+        assert_eq!(true, seq.contains(&good_needle).unwrap());
+    }
+
+    #[test]
+    fn test_seq_concat() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v : Vec<i32> = vec![1, 2, 3];
+        let concat_v : Vec<i32> = vec![1, 2, 3, 1, 2, 3];
+        let seq = PySequence::from_object(v.to_py_object(py).into_object()).unwrap();
+        let concat_seq = seq.concat(&seq).unwrap();
+        assert_eq!(6, concat_seq.length());
+        assert_eq!(concat_v, concat_seq.into_object().extract::<Vec<i32>>().unwrap());
+    }
+
+    #[test]
+    fn test_seq_concat_string() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = "string";
+        let concat_v = "stringstring";
+        let seq = PySequence::from_object(v.to_py_object(py).into_object()).unwrap();
+        let concat_seq = seq.concat(&seq).unwrap();
+        assert_eq!(12, concat_seq.length());
+        //assert_eq!(concat_v, concat_seq.into_object().extract::<String>().unwrap());
+    }
+
+
+    #[test]
+    fn test_seq_repeat() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = vec!["foo", "bar"];
+        let repeated = vec!["foo", "bar", "foo", "bar", "foo", "bar"];
+        let seq = PySequence::from_object(v.to_py_object(py).into_object()).unwrap();
+        let repeat_seq = seq.repeat(3).unwrap();
+        assert_eq!(6, repeat_seq.length());
+        //assert_eq!(repeated, repeat_seq.into_object().extract::<Vec<String>>().unwrap());
+    }
+}

--- a/src/objects/tuple.rs
+++ b/src/objects/tuple.rs
@@ -42,21 +42,6 @@ impl <'p> PyTuple<'p> {
         }
     }
 
-    /// Construct a tuple from an existing object.
-    #[inline]
-    pub fn from_object(obj: PyObject<'p>) -> PyResult<'p, PyTuple> {
-        let py = obj.python();
-        let ptr = obj.as_ptr();
-        unsafe {
-            if ffi::PyTuple_Check(ptr) != 0{
-                Ok(PyTuple(obj))
-            } else {
-                Err(PyErr::fetch(py))
-            }
-        }
-    }
-
-
     /// Retrieves the empty tuple.
     pub fn empty(py: Python<'p>) -> PyTuple<'p> {
         unsafe {

--- a/src/objects/tuple.rs
+++ b/src/objects/tuple.rs
@@ -24,7 +24,7 @@ use ffi::{self, Py_ssize_t};
 use conversion::{ToPyObject, ExtractPyObject};
 
 /// Represents a Python tuple object.
-pub struct PyTuple<'p>(PyObject<'p>);
+pub struct PyTuple<'p>(pub PyObject<'p>);
 
 pyobject_newtype!(PyTuple, PyTuple_Check, PyTuple_Type);
 

--- a/src/objects/tuple.rs
+++ b/src/objects/tuple.rs
@@ -17,14 +17,14 @@
 // DEALINGS IN THE SOFTWARE.
 
 use python::{Python, PythonObject, ToPythonPointer};
-use err::{self, PyResult, PyErr};
+use err::{self, PyErr, PyResult};
 use super::object::PyObject;
 use super::exc;
 use ffi::{self, Py_ssize_t};
 use conversion::{ToPyObject, ExtractPyObject};
 
 /// Represents a Python tuple object.
-pub struct PyTuple<'p>(pub PyObject<'p>);
+pub struct PyTuple<'p>(PyObject<'p>);
 
 pyobject_newtype!(PyTuple, PyTuple_Check, PyTuple_Type);
 
@@ -41,6 +41,21 @@ impl <'p> PyTuple<'p> {
             t
         }
     }
+
+    /// Construct a tuple from an existing object.
+    #[inline]
+    pub fn from_object(obj: PyObject<'p>) -> PyResult<'p, PyTuple> {
+        let py = obj.python();
+        let ptr = obj.as_ptr();
+        unsafe {
+            if ffi::PyTuple_Check(ptr) != 0{
+                Ok(PyTuple(obj))
+            } else {
+                Err(PyErr::fetch(py))
+            }
+        }
+    }
+
 
     /// Retrieves the empty tuple.
     pub fn empty(py: Python<'p>) -> PyTuple<'p> {


### PR DESCRIPTION
This adds support for the Sequence protocol.

Some notes: 

I use `into_object().cast_into::<PySequence>().unwrap()` in the tests because otherwise `to_py_object` would just resolve to the base type (`PyList`, `PyTuple`, etc).

I can't `extract` which I think gets in the way of making interesting assertions on `get_slice` and `set_slice`.
