### PR TITLE
Get a mutable reference to Rust objects in Python types

### DIFF
--- a/src/rustobject/class.rs
+++ b/src/rustobject/class.rs
@@ -30,7 +30,7 @@ pub trait PythonObjectFromPyClassMacro : python::PythonObjectWithTypeObject {
 # Example
 ```
 #[macro_use] extern crate cpython;
-use cpython::{Python, PyResult, PyType, PyDict};
+use cpython::{Python, PyResult, PyType, PyDict, PyObject};
 
 py_class!(class MyType, data: i32, |py| {
     def __new__(_cls: &PyType, arg: i32) -> PyResult<MyType> {
@@ -39,6 +39,11 @@ py_class!(class MyType, data: i32, |py| {
     def half(&self) -> PyResult<i32> {
         println!("half() was called with self={:?}", self.data(py));
         Ok(self.data(py) / 2)
+    }
+
+    def set(&self, data: i32) -> PyResult<PyObject> {
+        *self.inner_mut(py) = data;
+        Ok(py.None())
     }
 });
 
@@ -95,6 +100,10 @@ macro_rules! py_class_impl {
         impl $name {
             pub fn $data_name<'a>(&'a self, py: $crate::Python<'a>) -> &'a $data_ty {
                 self.0.get(py)
+            }
+
+            pub fn inner_mut<'a>(&'a self, py: $crate::Python<'a>) -> &'a mut $data_ty {
+                self.0.get_mut(py)
             }
 
             pub fn create_instance(py: $crate::Python, $( $param_name : $param_ty ),* ) -> $name {
@@ -305,4 +314,3 @@ macro_rules! py_class_parse_body {
         py_class_parse_body!($class, $py, $b, $($remainder)*);
     );
 }
-

--- a/src/rustobject/mod.rs
+++ b/src/rustobject/mod.rs
@@ -127,6 +127,18 @@ impl <T, B> PyRustObject<T, B> where T: 'static + Send, B: BaseObject {
             &*ptr
         }
     }
+
+    /// Gets a mutable reference to the rust value stored in this Python object.
+    #[inline]
+    pub fn get_mut<'a>(&'a self, _py: Python<'a>) -> &'a mut T {
+        // We require the `Python` token to access the contained value,
+        // because `PyRustObject` is `Sync` even if `T` is `!Sync`.
+        let offset = PyRustObject::<T, B>::offset() as isize;
+        unsafe {
+            let ptr = (self.obj.as_ptr() as *mut u8).offset(offset) as *mut T;
+            &mut *ptr
+        }
+    }
 }
 
 impl <T, B> BaseObject for PyRustObject<T, B> where T: 'static + Send, B: BaseObject {
@@ -283,4 +295,3 @@ impl <T, B> PythonObject for PyRustType<T, B> where T: 'static + Send, B: BaseOb
         mem::transmute(obj)
     }
 }
-


### PR DESCRIPTION
**[Not ready to merge]**

I am not sure of what I am doing with PyRustObject, but the documentation says:

> Because all Python objects potentially have multiple owners, the concept of Rust mutability does not apply to Python objects. As a result, this API will allow mutating Python objects even if they are not stored in a mutable Rust variable.

Is there any way to create a function with name `$data_name + _mut` in  the `py_clas_impl!` macro?