### PR TITLE
get_macos_linkmodel fix

### DIFF
--- a/python3-sys/build.rs
+++ b/python3-sys/build.rs
@@ -189,7 +189,7 @@ fn get_rustc_link_lib(_: &PythonVersion, ld_version: &str, enable_shared: bool) 
 
 #[cfg(target_os="macos")]
 fn get_macos_linkmodel() -> Result<String, String> {
-    let script = "import MacOS; print MacOS.linkmodel;";
+    let script = "import sysconfig; print('framework' if sysconfig.get_config_var('PYTHONFRAMEWORK') else ('shared' if sysconfig.get_config_var('Py_ENABLE_SHARED') else 'static'));";
     let out = run_python_script("python", script).unwrap();
     Ok(out.trim_right().to_owned())
 }


### PR DESCRIPTION
The script had two issues: the ```print``` statement and the nonexistent ```MacOS``` module (in Python 3)
I propose this workaround that works fine in my two test systems. The first one uses the system python and prints 'framework' as it should. The second one uses Anaconda and prints 'shared' as expected.

I don't consider myself a *Pythonista* so, if there's a better way to fix this then by all means.