### PR TITLE
Make struct generated with py_class! public

### DIFF
--- a/extensions/btree.rs
+++ b/extensions/btree.rs
@@ -14,7 +14,7 @@ py_module_initializer!(btree, initbtree, PyInit_btree, |py, m| {
 
 /// Newtype around PyObject that implements Ord using python value comparisons.
 /// Python exceptions are converted into Rust panics.
-struct OrdPyObject(PyObject);
+pub struct OrdPyObject(PyObject);
 
 impl PartialEq for OrdPyObject {
     fn eq(&self, _other: &Self) -> bool {

--- a/src/py_class/py_class_impl.py
+++ b/src/py_class/py_class_impl.py
@@ -45,7 +45,7 @@ base_case = '''
         }
         $slots:tt { $( $imp:item )* } $members:tt;
     } => {
-        struct $class { _unsafe_inner: $crate::PyObject }
+        pub struct $class { _unsafe_inner: $crate::PyObject }
 
         pyobject_to_pyobject!($class);
 

--- a/src/py_class/py_class_impl.rs
+++ b/src/py_class/py_class_impl.rs
@@ -39,7 +39,7 @@ macro_rules! py_class_impl {
         }
         $slots:tt { $( $imp:item )* } $members:tt;
     } => {
-        struct $class { _unsafe_inner: $crate::PyObject }
+        pub struct $class { _unsafe_inner: $crate::PyObject }
 
         pyobject_to_pyobject!($class);
 

--- a/tests/test_class.rs
+++ b/tests/test_class.rs
@@ -87,7 +87,7 @@ fn new_with_two_args() {
     assert_eq!(*obj._data2(py), 20);
 }
 
-struct TestDropCall {
+pub struct TestDropCall {
     drop_called: Arc<AtomicBool>
 }
 impl Drop for TestDropCall {


### PR DESCRIPTION
So it can be defined not only in `lib.rs`.