### PR TITLE
Add py_exception! macro for defining custom exception types

### DIFF
--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -38,6 +38,7 @@ pub use self::num::PyLong as PyInt;
 pub use self::num::{PyLong, PyFloat};
 pub use self::sequence::PySequence;
 
+#[macro_export]
 macro_rules! pyobject_newtype(
     ($name: ident) => (
         py_impl_to_py_object_for_python_object!($name);


### PR DESCRIPTION
First of all, thank you for this awesome library! This is great for writing native extension modules. This PR adds support for defining custom exception types using `PyErr_NewException` by defining a new macro `py_exception!(modulename, ExceptionName[, BaseExceptionType])`. cc @dgrunwald 