### PR TITLE
Make py_class!'s generated type public

### DIFF
--- a/extensions/btree.rs
+++ b/extensions/btree.rs
@@ -14,7 +14,7 @@ py_module_initializer!(btree, initbtree, PyInit_btree, |py, m| {
 
 /// Newtype around PyObject that implements Ord using python value comparisons.
 /// Python exceptions are converted into Rust panics.
-struct OrdPyObject(PyObject);
+pub struct OrdPyObject(PyObject);
 
 impl PartialEq for OrdPyObject {
     fn eq(&self, _other: &Self) -> bool {

--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -120,7 +120,7 @@ pub fn parse_args(
 ///    5. `*name : ty`
 ///    6. `**name`
 ///    7. `**name : ty`
-///   The types used must implement the `ExtractPyObject` trait.
+///   The types used must implement the `FromPyObject` trait.
 ///   If no type is specified, the parameter implicitly uses
 ///   `&PyObject` (format 1), `&PyTuple` (format 4) or `&PyDict` (format 6).
 ///   If a default value is specified, it must be a compile-time constant

--- a/src/err.rs
+++ b/src/err.rs
@@ -164,7 +164,10 @@ impl PyErr {
         };
 
         unsafe {
-            let ptr: *mut ffi::PyObject = ffi::PyErr_NewException(name.as_ptr() as *mut c_char, base, dict);
+            let null_terminated_name = CString::new(name).unwrap();
+            let ptr: *mut ffi::PyObject = ffi::PyErr_NewException(null_terminated_name.as_ptr() as *mut c_char,
+                                                                  base,
+                                                                  dict);
             PyObject::from_borrowed_ptr(py, ptr).unchecked_cast_into::<PyType>()
         }
     }

--- a/src/function.rs
+++ b/src/function.rs
@@ -49,8 +49,9 @@ macro_rules! py_method_def {
 /// Creates a Python callable object that invokes a Rust function.
 ///
 /// There are two forms of this macro:
-/// 1) `py_fn!(py, f(parameter_list))`
-/// 2) `py_fn!(py, f(parameter_list) -> PyResult<T> { body })`
+///
+/// 1. `py_fn!(py, f(parameter_list))`
+/// 1. `py_fn!(py, f(parameter_list) -> PyResult<T> { body })`
 ///
 /// All three forms return a value of type `PyObject`.
 /// This python object is a callable object that invokes
@@ -60,13 +61,15 @@ macro_rules! py_method_def {
 /// the Rust types specified in the parameter list.
 /// See `py_argparse!()` for details on argument parsing.
 ///
-/// Form 1: 
+/// Form 1:
+///
 /// * `py` must be an expression of type `Python`
 /// * `f` must be the name of a function that is compatible with the specified
 ///    parameter list, except that a single parameter of type `Python` is prepended.
 ///    The function must return `PyResult<T>` for some `T` that implements `ToPyObject`.
 ///
 /// Form 2:
+///
 /// * `py` must be an identifier refers to a `Python` value.
 ///   The function body will also have access to a `Python` variable of this name.
 /// * `f` must be an identifier.

--- a/src/py_class/py_class.rs
+++ b/src/py_class/py_class.rs
@@ -302,15 +302,15 @@ py_class!(class MyIterator |py| {
 
     `__length_hint__` is new in Python 3.4; older versions will ignore the method.
 
-  * `def __getitem__(&self, key: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
+  * `def __getitem__(&self, key: impl FromPyObject) -> PyResult<impl ToPyObject>`
 
     Called by the Python subscript operator `self[key]`.
 
-  * `def __setitem__(&self, key: impl ExtractPyObject, value: impl ExtractPyObject) -> PyResult<()>`
+  * `def __setitem__(&self, key: impl FromPyObject, value: impl FromPyObject) -> PyResult<()>`
 
     Called by Python `self[key] = value`.
 
-  * `def __delitem__(&self, key: impl ExtractPyObject) -> PyResult<()>`
+  * `def __delitem__(&self, key: impl FromPyObject) -> PyResult<()>`
 
     Called by Python `del self[key]`.
 
@@ -319,7 +319,7 @@ py_class!(class MyIterator |py| {
     Called by the `reversed()` built-in.
     It should return a new iterator object that iterates over all the objects in the container in reverse order.
 
-  * `def __contains__(&self, item: impl ExtractPyObject) -> PyResult<bool>`
+  * `def __contains__(&self, item: impl FromPyObject) -> PyResult<bool>`
 
     Called by Python `item in self`.
     For mapping types, this should consider the keys of the mapping rather than the values
@@ -351,18 +351,18 @@ py_class!(class MyIterator |py| {
     If you can't handle the combination of types you've been given,
     you should return `Ok(py.NotImplemented())`.
 
-  * `def __iadd__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
-  * `def __isub__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
-  * `def __imul__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
-  * `def __imatmul__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
-  * `def __itruediv__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
-  * `def __ifloordiv__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
-  * `def __imod__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
-  * `def __ilshift__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
-  * `def __irshift__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
-  * `def __iand__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
-  * `def __ixor__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
-  * `def __ior__(&self, other: impl ExtractPyObject) -> PyResult<impl ToPyObject>`
+  * `def __iadd__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `def __isub__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `def __imul__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `def __imatmul__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `def __itruediv__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `def __ifloordiv__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `def __imod__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `def __ilshift__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `def __irshift__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `def __iand__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `def __ixor__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `def __ior__(&self, other: impl FromPyObject) -> PyResult<impl ToPyObject>`
 
     Handles inplace operations if possible, falling back to the non-inplace versions.
     These methods must return a new reference! In the common case of returning the

--- a/src/py_class/py_class_impl.py
+++ b/src/py_class/py_class_impl.py
@@ -48,7 +48,7 @@ base_case = '''
         }
         $slots:tt { $( $imp:item )* } $members:tt
     } => {
-        struct $class { _unsafe_inner: $crate::PyObject }
+        pub struct $class { _unsafe_inner: $crate::PyObject }
 
         py_impl_to_py_object_for_python_object!($class);
         py_impl_from_py_object_for_python_object!($class);
@@ -771,4 +771,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -40,7 +40,7 @@ macro_rules! py_class_impl {
         }
         $slots:tt { $( $imp:item )* } $members:tt
     } => {
-        struct $class { _unsafe_inner: $crate::PyObject }
+        pub struct $class { _unsafe_inner: $crate::PyObject }
 
         py_impl_to_py_object_for_python_object!($class);
         py_impl_from_py_object_for_python_object!($class);

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -40,7 +40,7 @@ macro_rules! py_class_impl {
         }
         $slots:tt { $( $imp:item )* } $members:tt
     } => {
-        struct $class { _unsafe_inner: $crate::PyObject }
+        pub struct $class { _unsafe_inner: $crate::PyObject }
 
         py_impl_to_py_object_for_python_object!($class);
         py_impl_from_py_object_for_python_object!($class);

--- a/tests/test_class.rs
+++ b/tests/test_class.rs
@@ -93,7 +93,7 @@ fn new_with_two_args() {
     assert_eq!(*obj._data2(py), 20);
 }
 
-struct TestDropCall {
+pub struct TestDropCall {
     drop_called: Arc<AtomicBool>
 }
 impl Drop for TestDropCall {


### PR DESCRIPTION
This PR contains the following changes:
* make the type generated by `py_class!` public
* replace `ExtractPyObject` with `FromPyObject` in the documentation