### PR TITLE
Use uppercase names for static variables to fix warnings

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -30,19 +30,19 @@ use err::{self, PyResult};
 #[doc(hidden)]
 macro_rules! py_method_def {
     ($name: expr, $flags: expr, $wrap: expr) => {{
-        static mut method_def: $crate::_detail::ffi::PyMethodDef = $crate::_detail::ffi::PyMethodDef {
+        static mut METHOD_DEF: $crate::_detail::ffi::PyMethodDef = $crate::_detail::ffi::PyMethodDef {
             //ml_name: bytes!(stringify!($name), "\0"),
             ml_name: 0 as *const $crate::_detail::libc::c_char,
             ml_meth: None,
             ml_flags: $crate::_detail::ffi::METH_VARARGS | $crate::_detail::ffi::METH_KEYWORDS | $flags,
             ml_doc: 0 as *const $crate::_detail::libc::c_char
         };
-        method_def.ml_name = concat!($name, "\0").as_ptr() as *const _;
-        method_def.ml_meth = Some(
+        METHOD_DEF.ml_name = concat!($name, "\0").as_ptr() as *const _;
+        METHOD_DEF.ml_meth = Some(
             ::std::mem::transmute::<$crate::_detail::ffi::PyCFunctionWithKeywords,
                                   $crate::_detail::ffi::PyCFunction>($wrap)
         );
-        &mut method_def
+        &mut METHOD_DEF
     }}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ macro_rules! py_module_initializer {
             fn init($py_id: $crate::Python, $m_id: &$crate::PyModule) -> $crate::PyResult<()> {
                 $body
             }
-            static mut module_def: $crate::_detail::ffi::PyModuleDef = $crate::_detail::ffi::PyModuleDef {
+            static mut MODULE_DEF: $crate::_detail::ffi::PyModuleDef = $crate::_detail::ffi::PyModuleDef {
                 m_base: $crate::_detail::ffi::PyModuleDef_HEAD_INIT,
                 m_name: 0 as *const _,
                 m_doc: 0 as *const _,
@@ -318,8 +318,8 @@ macro_rules! py_module_initializer {
             };
             // We can't convert &'static str to *const c_char within a static initializer,
             // so we'll do it here in the module initialization:
-            module_def.m_name = concat!(stringify!($name), "\0").as_ptr() as *const _;
-            $crate::py_module_initializer_impl(&mut module_def, init)
+            MODULE_DEF.m_name = concat!(stringify!($name), "\0").as_ptr() as *const _;
+            $crate::py_module_initializer_impl(&mut MODULE_DEF, init)
         }
     }
 }


### PR DESCRIPTION
@dgrunwald 