### PR TITLE
Implement optional values in argparse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,20 +59,20 @@
 //! extern crate cpython;
 //!
 //! use cpython::{Python, PyDict, PyResult};
-//! 
+//!
 //! fn main() {
 //!     let gil = Python::acquire_gil();
 //!     hello(gil.python()).unwrap();
 //! }
-//! 
+//!
 //! fn hello(py: Python) -> PyResult<()> {
 //!     let sys = py.import("sys")?;
 //!     let version: String = sys.get(py, "version")?.extract(py)?;
-//! 
+//!
 //!     let locals = PyDict::new(py);
 //!     locals.set_item(py, "os", py.import("os")?)?;
 //!     let user: String = py.eval("os.getenv('USER') or os.getenv('USERNAME')", None, Some(&locals))?.extract(py)?;
-//! 
+//!
 //!     println!("Hello {}, I'm Python {}", user, version);
 //!     Ok(())
 //! }
@@ -238,7 +238,7 @@ pub mod _detail {
 /// ```
 /// The full example project can be found at:
 ///   https://github.com/dgrunwald/rust-cpython/tree/master/extensions/hello
-/// 
+///
 /// Rust will compile the code into a file named `libhello.so`, but we have to
 /// rename the file in order to use it with Python:
 ///
@@ -357,4 +357,3 @@ pub unsafe fn py_module_initializer_impl(
     mem::forget(guard);
     ret
 }
-


### PR DESCRIPTION
I was missing this from #39, and I finally got my head around the code, so here is an implementation of the optional parameters in parameters lists.

I am not sure I understood all the interaction between all the `*Object` traits, so the code might not be optimal. In particular, I don't really get what this line is doing, and if it is the best way to do it:

```rust
$iter.next().unwrap().as_ref().unwrap_or(<$ptype as $crate::ToPyObject>::into_py_object($default, $py).as_object())
```

Tell me what you think!