### PR TITLE
Fix cpython dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ name = "rust2py"
 crate-type = ["cdylib"]
 
 [dependencies.cpython]
-path = "../.."
+version = "0.1"
 features = ["extension-module"]
 ```
 


### PR DESCRIPTION
This is a small fix.

Thanks for creating this crate! It's really awesome, and the ability to create Python extension modules is very useful for a project I'm working on.