### PR TITLE
Add support for osx builds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,173 @@
+# #####################################################################
+# Note: Revert to a simpler matrix definition once the travis builtin
+#       osx python build will be correctly configured.
+# #####################################################################
+#
+# Execute this code installing *cogapp* from PyPI and then:
+# `cog.py -r .travis.yml` to update inplace.
+#[[[cog
+#import cog
+#PYTHON_VERSIONS = ('2.7', '3.3', '3.4', '3.5', '3.6')
+#RUST_VERSIONS = {'1.13.0', 'nightly'}
+#allowed_failures = {'nightly'}
+#includes = """\
+#- os: osx
+#  language: generic
+#  python: {pyver}
+#  env: RUST_VERSION={rustver} BREW_PYTHON={brew_python}
+#  sudo: false\
+#"""
+#]]]
+#[[[end]]]
+
+os: linux
 language: python
 python:
+  #[[[cog
+  #for pyver in PYTHON_VERSIONS:
+  #    cog.outl('- "{pyver}"'.format(**locals()))
+  #]]]
   - "2.7"
   - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  #[[[end]]]
 env:
+  #[[[cog
+  #for rustver in RUST_VERSIONS:
+  #    cog.outl("- RUST_VERSION={rustver}".format(**locals()))
+  #]]]
   - RUST_VERSION=1.13.0
   - RUST_VERSION=nightly
+  - RUST_VERSION=1.15.0
+  #[[[end]]]
 sudo: false
+
+matrix:
+  include:
+    #[[[cog
+    #for pyver in sorted(PYTHON_VERSIONS):
+    #    brew_python = "python{v}".format(v=pyver.replace(".", ""))
+    #    for rustver in sorted(RUST_VERSIONS):
+    #        cog.outl(includes.format(**locals()))
+    #]]]
+    - os: osx
+      language: generic
+      python: 2.7
+      env: RUST_VERSION=1.13.0 BREW_PYTHON=python27
+      sudo: false
+    - os: osx
+      language: generic
+      python: 2.7
+      env: RUST_VERSION=1.15.0 BREW_PYTHON=python27
+      sudo: false
+    - os: osx
+      language: generic
+      python: 2.7
+      env: RUST_VERSION=nightly BREW_PYTHON=python27
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.3
+      env: RUST_VERSION=1.13.0 BREW_PYTHON=python33
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.3
+      env: RUST_VERSION=1.15.0 BREW_PYTHON=python33
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.3
+      env: RUST_VERSION=nightly BREW_PYTHON=python33
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.4
+      env: RUST_VERSION=1.13.0 BREW_PYTHON=python34
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.4
+      env: RUST_VERSION=1.15.0 BREW_PYTHON=python34
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.4
+      env: RUST_VERSION=nightly BREW_PYTHON=python34
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.5
+      env: RUST_VERSION=1.13.0 BREW_PYTHON=python35
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.5
+      env: RUST_VERSION=1.15.0 BREW_PYTHON=python35
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.5
+      env: RUST_VERSION=nightly BREW_PYTHON=python35
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.6
+      env: RUST_VERSION=1.13.0 BREW_PYTHON=python36
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.6
+      env: RUST_VERSION=1.15.0 BREW_PYTHON=python36
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.6
+      env: RUST_VERSION=nightly BREW_PYTHON=python36
+      sudo: false
+    #[[[end]]]
+  allow_failures:
+    #[[[cog
+    #for pyver in sorted(PYTHON_VERSIONS):
+    #    brew_python = "python{v}".format(v=pyver.replace(".", ""))
+    #    for rustver in sorted(RUST_VERSIONS & allowed_failures):
+    #        cog.outl(includes.format(**locals()))
+    #]]]
+    - os: osx
+      language: generic
+      python: 2.7
+      env: RUST_VERSION=nightly BREW_PYTHON=python27
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.3
+      env: RUST_VERSION=nightly BREW_PYTHON=python33
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.4
+      env: RUST_VERSION=nightly BREW_PYTHON=python34
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.5
+      env: RUST_VERSION=nightly BREW_PYTHON=python35
+      sudo: false
+    - os: osx
+      language: generic
+      python: 3.6
+      env: RUST_VERSION=nightly BREW_PYTHON=python36
+      sudo: false
+    #[[[end]]]
+
+#  Manually install python on osx
+before_install:
+  - if [[ $TRAVIS_OS_NAME == 'osx' && $BREW_PYTHON != 'python27' ]]; then ci/osx-install.sh; fi
+
 install:
+  - python -V
   - python -c "import sysconfig; print('\n'.join(map(repr,sorted(sysconfig.get_config_vars().items()))))"
   - mkdir ~/rust-installer
   - curl -sL https://static.rust-lang.org/rustup.sh -o ~/rust-installer/rustup.sh
@@ -20,6 +178,6 @@ install:
   - export LIBRARY_PATH="$LIBRARY_PATH:$PYTHON_LIB"
   - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PYTHON_LIB:$HOME/rust/lib"
   - rustc -V
+
 script:
   - make test extensions
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@
 #import cog
 #PYTHON_VERSIONS = ('2.7', '3.3', '3.4', '3.5', '3.6')
 #RUST_VERSIONS = {'1.13.0', 'nightly'}
+#stable = open('.rust.stable').read().strip()
+#RUST_VERSIONS.add(stable)
 #allowed_failures = {'nightly'}
 #includes = """\
 #- os: osx

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,10 @@ src/py_class/py_class_impl2.rs: src/py_class/py_class_impl.py
 src/py_class/py_class_impl3.rs: src/py_class/py_class_impl.py
 	PY=3 python $< >$@
 
-cog: python27-sys/build.rs .travis.yml
+.rust.stable:
+	curl -s https://static.rust-lang.org/dist/channel-rust-stable.toml | grep -A1 "\[pkg.rust\]" | tail -1 | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" > $@
+
+cog: python27-sys/build.rs .travis.yml .rust.stable
 	cog.py -r $^
 
 build: src/py_class/py_class_impl2.rs src/py_class/py_class_impl3.rs
@@ -56,6 +59,7 @@ extensions: build
 
 clean:
 	rm -r target
+	rm -f .rust.stable
 	make -C extensions/ clean
 
 gh-pages:

--- a/ci/osx-install.sh
+++ b/ci/osx-install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+brew tap naufraghi/python
+brew install $BREW_PYTHON

--- a/tests/check_symbols.py
+++ b/tests/check_symbols.py
@@ -14,7 +14,8 @@ if platform.system() == 'Windows' or platform.system().startswith('CYGWIN'):
 
 so_files = [
     sysconfig.get_config_var("LIBDIR")+"/"+sysconfig.get_config_var("LDLIBRARY"),
-    sysconfig.get_config_var("LIBPL")+"/"+sysconfig.get_config_var("LDLIBRARY")
+    sysconfig.get_config_var("LIBPL")+"/"+sysconfig.get_config_var("LDLIBRARY"),
+    sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX")+"/"+sysconfig.get_config_var("LDLIBRARY"),
 ]
 so_file = None
 for name in so_files:
@@ -88,4 +89,3 @@ if names:
     sys.exit(1)
 else:
     print('Symbols in {} OK.'.format(so_file))
-


### PR DESCRIPTION
Related to Issue #9 

Given the fact the Python language support in Travis is currently broken, see https://travis-ci.org/naufraghi/rust-cpython/jobs/198527502, we use the declarative matrix syntax for Linux, and we manually generate the osx matrix, installing Python in a `before_install` step using brew.

The same generation code is used to generate the `allow_failures` block.