### PR TITLE
allow to use class as base class

### DIFF
--- a/src/py_class/slots.rs
+++ b/src/py_class/slots.rs
@@ -71,11 +71,12 @@ macro_rules! py_class_type_object_flags {
 }
 
 #[cfg(feature="python27-sys")]
-pub const TPFLAGS_DEFAULT : ::libc::c_long = ffi::Py_TPFLAGS_DEFAULT
-                                           | ffi::Py_TPFLAGS_CHECKTYPES;
+pub const TPFLAGS_DEFAULT : ::libc::c_long =
+    ffi::Py_TPFLAGS_DEFAULT | ffi::Py_TPFLAGS_CHECKTYPES | ffi::Py_TPFLAGS_BASETYPE;
 
 #[cfg(feature="python3-sys")]
-pub const TPFLAGS_DEFAULT : ::libc::c_ulong = ffi::Py_TPFLAGS_DEFAULT;
+pub const TPFLAGS_DEFAULT : ::libc::c_ulong =
+    ffi::Py_TPFLAGS_DEFAULT | ffi::Py_TPFLAGS_BASETYPE;
 
 #[macro_export]
 #[doc(hidden)]


### PR DESCRIPTION
Allow to use classes defined in rust as base class for python classes