### PR TITLE
Python class properties

### DIFF
--- a/src/py_class/mod.rs
+++ b/src/py_class/mod.rs
@@ -23,6 +23,7 @@ mod py_class_impl2;
 mod py_class_impl3;
 #[doc(hidden)] pub mod slots;
 #[doc(hidden)] pub mod members;
+#[doc(hidden)] pub mod properties;
 pub mod gc;
 
 use libc;

--- a/src/py_class/properties.rs
+++ b/src/py_class/properties.rs
@@ -1,0 +1,137 @@
+use ffi;
+
+pub fn type_error_to_unit(py: ::Python, e: ::PyErr) -> ::PyResult<()> {
+    if e.matches(py, py.get_type::<::exc::TypeError>()) {
+        Ok(())
+    } else {
+        Err(e)
+    }
+}
+
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! py_class_init_properties {
+    ($class:ident, $py:ident, $type_object: ident, { }) => {{}};
+    ($class:ident, $py:ident, $type_object: ident, { $( $prop:expr; )+ }) =>
+    { unsafe {
+        let mut defs = Vec::new();
+        $(defs.push($prop);)+
+        defs.push(
+            $crate::_detail::ffi::PyGetSetDef {
+                name: 0 as *mut $crate::_detail::libc::c_char,
+                get: None,
+                set: None,
+                doc: 0 as *mut $crate::_detail::libc::c_char,
+                closure: 0 as *mut $crate::_detail::libc::c_void,
+            });
+        let props = defs.into_boxed_slice();
+
+        $type_object.tp_getset =
+            props.as_ptr() as *mut $crate::_detail::ffi::PyGetSetDef;
+        std::mem::forget(props);
+    }};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! py_class_property_impl {
+
+    ({} $class:ident $py:ident $name:ident { $( $descr_name:ident = $descr_expr:expr; )* } ) =>
+    {{
+        let mut getset_def: $crate::_detail::ffi::PyGetSetDef =
+            $crate::_detail::ffi::PyGetSetDef {
+                name: 0 as *mut $crate::_detail::libc::c_char,
+                get: None,
+                set: None,
+                doc: 0 as *mut $crate::_detail::libc::c_char,
+                closure: 0 as *mut $crate::_detail::libc::c_void,
+            };
+        getset_def.name = concat!(stringify!($name), "\0").as_ptr() as *mut _;
+
+        $( getset_def.$descr_name = Some($descr_expr); )*
+
+        getset_def
+    }};
+
+    ( { get (&$slf:ident) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
+        $class:ident $py:ident $name:ident { $( $descr_name:ident = $descr_expr:expr; )* } ) =>
+    {
+        py_class_property_impl!{
+            { $($tail)* } $class $py $name
+            /* methods: */ {
+                $( $descr_name = $descr_expr; )*
+                get = {
+                    unsafe extern "C" fn wrap_getter_method(
+                        slf: *mut $crate::_detail::ffi::PyObject,
+                        _: *mut $crate::_detail::libc::c_void)
+                        -> *mut $crate::_detail::ffi::PyObject
+                    {
+                        const LOCATION: &'static str = concat!(
+                            stringify!($class), ".getter_", stringify!($name), "()");
+
+                        fn get($slf: &$class, $py: $crate::Python) -> $res_type {
+                            $($body)*
+                        };
+
+                        $crate::_detail::handle_callback(
+                            LOCATION, $crate::_detail::PyObjectCallbackConverter,
+                            |py| {
+                                let slf = $crate::PyObject::from_borrowed_ptr(
+                                    py, slf).unchecked_cast_into::<$class>();
+                                let ret = get(&slf, py);
+                                $crate::PyDrop::release_ref(slf, py);
+                                ret
+                            })
+                    }
+                    wrap_getter_method
+                };
+            }
+        }
+    };
+
+    ( { set(&$slf:ident, $value:ident : $value_type:ty)
+            -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+        $class:ident $py:ident $name:ident { $( $descr_name:ident = $descr_expr:expr; )* } ) =>
+    {
+        py_class_property_impl! {
+            { $($tail)* } $class $py $name
+            /* methods: */ {
+                $( $descr_name = $descr_expr; )*
+                set = {
+                    unsafe extern "C" fn wrap_setter_method(
+                        slf: *mut $crate::_detail::ffi::PyObject,
+                        value: *mut $crate::_detail::ffi::PyObject,
+                        _: *mut $crate::_detail::libc::c_void)
+                        -> $crate::_detail::libc::c_int
+                    {
+                        const LOCATION: &'static str = concat!(
+                            stringify!($class), ".setter_", stringify!($name), "()");
+
+                        fn set($slf: &$class,
+                               $py: $crate::Python, $value: $value_type) -> $res_type {
+                            $($body)*
+                        };
+
+                        $crate::_detail::handle_callback(
+                            LOCATION, $crate::py_class::slots::UnitCallbackConverter, move |py| {
+                                let slf = $crate::PyObject::from_borrowed_ptr(py, slf)
+                                    .unchecked_cast_into::<$class>();
+                                let value = $crate::PyObject::from_borrowed_ptr(py, value);
+
+                                let ret = match <$value_type as $crate::FromPyObject>::extract(py, &value) {
+                                    Ok(value) => set(&slf, py, value),
+                                    Err(e) =>
+                                        $crate::py_class::properties::type_error_to_unit(py, e)
+                                };
+                                $crate::PyDrop::release_ref(slf, py);
+                                $crate::PyDrop::release_ref(value, py);
+                                ret
+                            })
+                    }
+                    wrap_setter_method
+                };
+            }
+        }
+    };
+}

--- a/src/py_class/properties.rs
+++ b/src/py_class/properties.rs
@@ -29,7 +29,9 @@ macro_rules! py_class_init_properties {
 
         $type_object.tp_getset =
             props.as_ptr() as *mut $crate::_detail::ffi::PyGetSetDef;
-        std::mem::forget(props);
+
+        use std::mem;
+        mem::forget(props);
     }};
 }
 

--- a/src/py_class/py_class.rs
+++ b/src/py_class/py_class.rs
@@ -423,6 +423,7 @@ macro_rules! py_class {
             }
             /* impls: */ { /* impl body */ }
             /* members: */ { /* ident = expr; */ }
+            /* properties: */ { /* expr; */ }
         }
     );
     (pub class $class:ident |$py: ident| { $( $body:tt )* }) => (
@@ -452,9 +453,11 @@ macro_rules! py_class {
             }
             /* impls: */ { /* impl body */ }
             /* members: */ { /* ident = expr; */ }
+            /* properties: */ { /* expr; */ }
         }
     );
 }
+
 
 #[macro_export]
 #[doc(hidden)]

--- a/src/py_class/py_class_impl.py
+++ b/src/py_class/py_class_impl.py
@@ -47,7 +47,7 @@ base_case = '''
             $gc:tt,
             /* data: */ [ $( { $data_offset:expr, $data_name:ident, $data_ty:ty } )* ]
         }
-        $slots:tt { $( $imp:item )* } $members:tt
+        $slots:tt { $( $imp:item )* } $members:tt $properties:tt
     } => {
         py_coerce_item! {
             $($class_visibility)* struct $class { _unsafe_inner: $crate::PyObject }
@@ -184,6 +184,7 @@ base_case = '''
                     fn init($py: $crate::Python, module_name: Option<&str>) -> $crate::PyResult<$crate::PyType> {
                         py_class_type_object_dynamic_init!($class, $py, TYPE_OBJECT, module_name, $slots);
                         py_class_init_members!($class, $py, TYPE_OBJECT, $members);
+                        py_class_init_properties!($class, $py, TYPE_OBJECT, $properties);
                         unsafe {
                             if $crate::_detail::ffi::PyType_Ready(&mut TYPE_OBJECT) == 0 {
                                 Ok($crate::PyType::from_type_ptr($py, &mut TYPE_OBJECT))
@@ -196,6 +197,18 @@ base_case = '''
             }
         }
     };
+
+    { { property $name:ident { $($body:tt)* } $($tail:tt)* }
+        $class:ident $py:ident $info:tt $slots:tt { $( $imp:item )* } $members:tt
+        { $( $properties:expr; )* }
+    } => { py_class_impl! {
+        { $($tail)* }
+        $class $py $info $slots { $($imp)* } $members
+        /* properties: */ {
+            $( $properties; )*
+            py_class_property_impl! { { $($body)* } $class $py $name { } };
+        }
+    }};
 '''
 
 indentation = ['    ']
@@ -285,6 +298,9 @@ def generate_case(pattern, old_info=None, new_info=None, new_impl=None, new_slot
         write('\n{ $( $member_name:ident = $member_expr:expr; )* }')
     else:
         write('$members:tt')
+
+    write('$properties:tt')
+
     write('\n} => { py_class_impl! {\n')
     write('{ $($tail)* }\n')
     write('$class $py')
@@ -327,6 +343,7 @@ def generate_case(pattern, old_info=None, new_info=None, new_impl=None, new_slot
         write('}')
     else:
         write('$members')
+    write('$properties')
     write('\n}};\n')
 
 def data_decl():

--- a/tests/test_class.rs
+++ b/tests/test_class.rs
@@ -878,3 +878,37 @@ fn context_manager() {
     assert!(c.exit_called(py).get());
 }
 
+
+py_class!(class ClassWithProperties |py| {
+    data num: Cell<i32>;
+
+    def get_num(&self) -> PyResult<i32> {
+        Ok(self.num(py).get())
+    }
+
+    property DATA {
+        get(&slf) -> PyResult<i32> {
+            Ok(slf.num(py).get())
+        }
+        set(&slf, value: i32) -> PyResult<()> {
+            slf.num(py).set(value);
+            Ok(())
+        }
+    }
+});
+
+
+#[test]
+fn class_with_properties() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let inst = ClassWithProperties::create_instance(py, Cell::new(10)).unwrap();
+
+    py_run!(py, inst, "assert inst.get_num() == 10");
+    py_run!(py, inst, "assert inst.get_num() == inst.DATA");
+    py_run!(py, inst, "inst.DATA = 20");
+    py_run!(py, inst, "assert inst.get_num() == 20");
+    py_run!(py, inst, "assert inst.get_num() == inst.DATA");
+
+}


### PR DESCRIPTION
Added class properties via PyGetSetDef

property definition looks like this:

```rust


py_class!(class ClassWithProperties |py| {
    data num: Cell<i32>;

    property DATA {
        get(&slf) -> PyResult<i32> {
            Ok(slf.num(py).get())
        }
        set(&slf, value: i32) -> PyResult<()> {
            slf.num(py).set(value);
            Ok(())
        }
    }
});
```

in this implementation it is not possible to use `&self`
