### PR TITLE
Update the regex dependency

### DIFF
--- a/python3-sys/Cargo.toml
+++ b/python3-sys/Cargo.toml
@@ -25,7 +25,7 @@ workspace = ".."
 libc = "0.2"
 
 [build-dependencies]
-regex = "0.1"
+regex = "0.2"
 
 [features]
 # This is examined by ./build.rs to determine which python version 

--- a/python3-sys/build.rs
+++ b/python3-sys/build.rs
@@ -221,8 +221,8 @@ fn get_interpreter_version(line: &str) -> Result<PythonVersion, String> {
     let version_re = Regex::new(r"\((\d+), (\d+)\)").unwrap();
     match version_re.captures(&line) {
         Some(cap) => Ok(PythonVersion {
-            major: cap.at(1).unwrap().parse().unwrap(),
-            minor: Some(cap.at(2).unwrap().parse().unwrap())
+            major: cap.get(1).unwrap().as_str().parse().unwrap(),
+            minor: Some(cap.get(2).unwrap().as_str().parse().unwrap())
         }),
         None => Err(
             format!("Unexpected response to version query {}", line))
@@ -361,10 +361,10 @@ fn version_from_env() -> Result<PythonVersion, String> {
     vars.sort_by(|a, b| b.cmp(a));
     for (key, _) in vars {
         match re.captures(&key) {
-            Some(cap) => return Ok(PythonVersion { 
-                major: cap.at(1).unwrap().parse().unwrap(), 
-                minor: match cap.at(3) {
-                    Some(s) => Some(s.parse().unwrap()),
+            Some(cap) => return Ok(PythonVersion {
+                major: cap.get(1).unwrap().as_str().parse().unwrap(),
+                minor: match cap.get(3) {
+                    Some(s) => Some(s.as_str().parse().unwrap()),
                     None => None
                 }
             }),


### PR DESCRIPTION
The `.at` method has been replaced by `.get` and now returns a `Match`.