### PR TITLE
Fixing pointer issues for ARM in python27-sys

### DIFF
--- a/python27-sys/src/objectabstract.rs
+++ b/python27-sys/src/objectabstract.rs
@@ -294,16 +294,16 @@ pub unsafe fn PyMapping_DelItem(o : *mut PyObject, key : *mut PyObject) -> c_int
 
 #[inline]
 pub unsafe fn PyMapping_Keys(o : *mut PyObject) -> *mut PyObject {
-    PyObject_CallMethod(o, "keys\0".as_ptr() as *mut i8, ptr::null_mut())
+    PyObject_CallMethod(o, "keys\0".as_ptr() as *mut _, ptr::null_mut())
 }
 
 #[inline]
 pub unsafe fn PyMapping_Values(o : *mut PyObject) -> *mut PyObject {
-    PyObject_CallMethod(o, "values\0".as_ptr() as *mut i8, ptr::null_mut())
+    PyObject_CallMethod(o, "values\0".as_ptr() as *mut _, ptr::null_mut())
 }
 
 #[inline]
 pub unsafe fn PyMapping_Items(o : *mut PyObject) -> *mut PyObject {
-    PyObject_CallMethod(o, "items\0".as_ptr() as *mut i8, ptr::null_mut())
+    PyObject_CallMethod(o, "items\0".as_ptr() as *mut _, ptr::null_mut())
 }
 


### PR DESCRIPTION
Letting the compiler figure out the pointer size since ARM used u8 for its pointer size instead of i8.