### PR TITLE
Initialize ob_type for class type objects early

### DIFF
--- a/python27-sys/src/object.rs
+++ b/python27-sys/src/object.rs
@@ -605,6 +605,13 @@ pub const PyTypeObject_INIT : PyTypeObject = PyTypeObject {
     tp_version_tag: 0,
 };
 
+impl PyTypeObject {
+    #[inline]
+    pub fn init_ob_type(&mut self, type_object: *mut PyTypeObject) {
+        self.ob_type = type_object;
+    }
+}
+
 #[repr(C)]
 #[derive(Copy)]
 pub struct PyHeapTypeObject {

--- a/python3-sys/src/object.rs
+++ b/python3-sys/src/object.rs
@@ -596,6 +596,13 @@ mod typeobject {
         tp_reserved,
     );
 
+    impl PyTypeObject {
+        #[inline]
+        pub fn init_ob_type(&mut self, type_object: *mut PyTypeObject) {
+            self.ob_base.ob_base.ob_type = type_object;
+        }
+    }
+
     #[repr(C)]
     #[derive(Copy)]
     pub struct PyHeapTypeObject {

--- a/src/py_class/slots.rs
+++ b/src/py_class/slots.rs
@@ -91,6 +91,7 @@ macro_rules! py_class_type_object_dynamic_init {
         }
     ) => {
         unsafe {
+            $type_object.init_ob_type(&mut $crate::_detail::ffi::PyType_Type);
             $type_object.tp_name = $crate::py_class::slots::build_tp_name($module_name, stringify!($class));
             $type_object.tp_basicsize = <$class as $crate::py_class::BaseObject>::size()
                                         as $crate::_detail::ffi::Py_ssize_t;


### PR DESCRIPTION
When creating classes, the `ob_type` field of the class's `PyTypeObject`
is statically initialized to `NULL`, and then becomes dynamically
initialized to `&PyType_Type` when `PyType_Ready()` is called.  This is
too late.  If GC occurs during the initialization of the class before
`PyType_Ready()` is called, then the garbage collector will encounter
the `NULL` `ob_type` and segfault.

The Python docs say this field should be dynamically initialized to
`&PyType_Type` before doing any more class initialization.