### PR TITLE
Add sysmodule for python27-sys

### DIFF
--- a/python27-sys/src/lib.rs
+++ b/python27-sys/src/lib.rs
@@ -48,6 +48,7 @@ pub use pyarena::*;
 pub use modsupport::*;
 pub use pythonrun::*;
 pub use ceval::*;
+pub use sysmodule::*;
 pub use import::*;
 pub use objectabstract::*;
 pub use code::*;
@@ -104,7 +105,7 @@ mod pyarena;
 mod modsupport;
 mod pythonrun;
 mod ceval;
-// mod sysmodule; // TODO: incomplete
+mod sysmodule;
 // mod intrcheck; // TODO: incomplete
 mod import;
 

--- a/python27-sys/src/sysmodule.rs
+++ b/python27-sys/src/sysmodule.rs
@@ -1,0 +1,15 @@
+use libc::{c_int, c_char};
+use object::PyObject;
+
+#[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
+    pub fn PySys_GetObject(arg1: *mut c_char) -> *mut PyObject;
+    pub fn PySys_SetObject(arg1: *mut c_char, arg2: *mut PyObject) -> c_int;
+    pub fn PySys_SetArgv(arg1: c_int, arg2: *mut *mut c_char) -> ();
+    pub fn PySys_SetArgvEx(arg1: c_int, arg2: *mut *mut c_char, arg3: c_int) -> ();
+    pub fn PySys_SetPath(arg1: *mut c_char) -> ();
+    pub fn PySys_WriteStdout(format: *const c_char, ...) -> ();
+    pub fn PySys_WriteStderr(format: *const c_char, ...) -> ();
+    pub fn PySys_ResetWarnOptions() -> ();
+    pub fn PySys_AddWarnOption(arg1: *mut c_char) -> ();
+    pub fn PySys_HasWarnOptions() -> c_int;
+}


### PR DESCRIPTION
I needed PySys_SetArgv[Ex] for an embedded Python use case. I went
ahead and declared the other functions.

I skipped PySys_GetFile() because it doesn't exist in Python 3
and we probably shouldn't be encouraging its use. Plus the use of FILE
from Rust is a bit wonky (especially on Windows, since official Python
2.7 distributions are linked against msvcr90 and Rust... won't be -
this would lead to mixing CRTs and badness occuring).

I also skipped _PySys_GetSizeOf(). It is exported. But the leading
underscore means you probably shouldn't use it.