### PR TITLE
Remove private svn and hg symbols

### DIFF
--- a/python27-sys/src/pythonrun.rs
+++ b/python27-sys/src/pythonrun.rs
@@ -112,10 +112,7 @@ pub enum Struct_symtable { }
     pub fn Py_GetCopyright() -> *const c_char;
     pub fn Py_GetCompiler() -> *const c_char;
     pub fn Py_GetBuildInfo() -> *const c_char;
-    fn _Py_svnversion() -> *const c_char;
     pub fn Py_SubversionRevision() -> *const c_char;
     pub fn Py_SubversionShortBranch() -> *const c_char;
-    fn _Py_hgidentifier() -> *const c_char;
-    fn _Py_hgversion() -> *const c_char;
 }
 


### PR DESCRIPTION
Upstream python removed `_Py_svnversion`, `_Py_hgversion` and
`_Py_hgidentifier` in https://github.com/python/cpython/pull/1327,
replacing them with `_Py_gitversion` and `_Py_gitidentifier`.

These are private symbols which shouldn't be exposed here anyway, so
just remove them.