### PR TITLE
Fix markdown in docs: +extra space before list items

### DIFF
--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -36,11 +36,11 @@ pub struct ParamDescription<'a> {
 
 /// Parse argument list
 ///
-/// * fname:  Name of the current function
-/// * params: Declared parameters of the function
-/// * args:   Positional arguments
-/// * kwargs: Keyword arguments
-/// * output: Output array that receives the arguments.
+///  * fname:  Name of the current function
+///  * params: Declared parameters of the function
+///  * args:   Positional arguments
+///  * kwargs: Keyword arguments
+///  * output: Output array that receives the arguments.
 ///           Must have same length as `params` and must be initialized to `None`.
 pub fn parse_args(
     py: Python,
@@ -107,11 +107,11 @@ pub fn parse_args(
 ///
 /// Syntax: `py_argparse!(py, fname, args, kwargs, (parameter-list) { body })`
 ///
-/// * `py`: the `Python` token
-/// * `fname`: expression of type `Option<&str>`: Name of the function used in error messages.
-/// * `args`: expression of type `&PyTuple`: The position arguments
-/// * `kwargs`: expression of type `Option<&PyDict>`: The named arguments
-/// * `parameter-list`: a comma-separated list of parameter declarations.
+///  * `py`: the `Python` token
+///  * `fname`: expression of type `Option<&str>`: Name of the function used in error messages.
+///  * `args`: expression of type `&PyTuple`: The position arguments
+///  * `kwargs`: expression of type `Option<&PyDict>`: The named arguments
+///  * `parameter-list`: a comma-separated list of parameter declarations.
 ///   Parameter declarations have one of these formats:
 ///    1. `name`
 ///    2. `name: ty`
@@ -126,7 +126,7 @@ pub fn parse_args(
 ///   `&PyObject` (format 1), `&PyTuple` (format 4) or `&PyDict` (format 6).
 ///   If a default value is specified, it must be a compile-time constant
 //    of type `ty`.
-/// * `body`: expression of type `PyResult<_>`.
+///  * `body`: expression of type `PyResult<_>`.
 ///     The extracted argument values are available in this scope.
 ///
 /// `py_argparse!()` expands to code that extracts values from `args` and `kwargs` and assigns

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -277,9 +277,9 @@ impl PyBuffer {
     /// Gets the buffer memory as a slice.
     ///
     /// This function succeeds if:
-    /// * the buffer format is compatible with `T`
-    /// * alignment and size of buffer elements is matching the expectations for type `T`
-    /// * the buffer is C-style contiguous
+    ///  * the buffer format is compatible with `T`
+    ///  * alignment and size of buffer elements is matching the expectations for type `T`
+    ///  * the buffer is C-style contiguous
     ///
     /// The returned slice uses type `Cell<T>` because it's theoretically possible for any call into the Python runtime
     /// to modify the values in the slice.
@@ -298,10 +298,10 @@ impl PyBuffer {
     /// Gets the buffer memory as a slice.
     ///
     /// This function succeeds if:
-    /// * the buffer is not read-only
-    /// * the buffer format is compatible with `T`
-    /// * alignment and size of buffer elements is matching the expectations for type `T`
-    /// * the buffer is C-style contiguous
+    ///  * the buffer is not read-only
+    ///  * the buffer format is compatible with `T`
+    ///  * alignment and size of buffer elements is matching the expectations for type `T`
+    ///  * the buffer is C-style contiguous
     ///
     /// The returned slice uses type `Cell<T>` because it's theoretically possible for any call into the Python runtime
     /// to modify the values in the slice.
@@ -321,9 +321,9 @@ impl PyBuffer {
     /// Gets the buffer memory as a slice.
     ///
     /// This function succeeds if:
-    /// * the buffer format is compatible with `T`
-    /// * alignment and size of buffer elements is matching the expectations for type `T`
-    /// * the buffer is Fortran-style contiguous
+    ///  * the buffer format is compatible with `T`
+    ///  * alignment and size of buffer elements is matching the expectations for type `T`
+    ///  * the buffer is Fortran-style contiguous
     ///
     /// The returned slice uses type `Cell<T>` because it's theoretically possible for any call into the Python runtime
     /// to modify the values in the slice.
@@ -342,10 +342,10 @@ impl PyBuffer {
     /// Gets the buffer memory as a slice.
     ///
     /// This function succeeds if:
-    /// * the buffer is not read-only
-    /// * the buffer format is compatible with `T`
-    /// * alignment and size of buffer elements is matching the expectations for type `T`
-    /// * the buffer is Fortran-style contiguous
+    ///  * the buffer is not read-only
+    ///  * the buffer format is compatible with `T`
+    ///  * alignment and size of buffer elements is matching the expectations for type `T`
+    ///  * the buffer is Fortran-style contiguous
     ///
     /// The returned slice uses type `Cell<T>` because it's theoretically possible for any call into the Python runtime
     /// to modify the values in the slice.

--- a/src/err.rs
+++ b/src/err.rs
@@ -144,9 +144,9 @@ impl PyErr {
     /// Creates a new PyErr of type `T`.
     ///
     /// `value` can be:
-    /// * `NoArgs`: the exception instance will be created using python `T()`
-    /// * a tuple: the exception instance will be created using python `T(*tuple)`
-    /// * any other value: the exception instance will be created using python `T(value)`
+    ///  * `NoArgs`: the exception instance will be created using python `T()`
+    ///  * a tuple: the exception instance will be created using python `T(*tuple)`
+    ///  * any other value: the exception instance will be created using python `T(value)`
     ///
     /// Panics if `T` is not a python class derived from `BaseException`.
     ///

--- a/src/function.rs
+++ b/src/function.rs
@@ -63,17 +63,17 @@ macro_rules! py_method_def {
 ///
 /// Form 1:
 ///
-/// * `py` must be an expression of type `Python`
-/// * `f` must be the name of a function that is compatible with the specified
+///  * `py` must be an expression of type `Python`
+///  * `f` must be the name of a function that is compatible with the specified
 ///    parameter list, except that a single parameter of type `Python` is prepended.
 ///    The function must return `PyResult<T>` for some `T` that implements `ToPyObject`.
 ///
 /// Form 2:
 ///
-/// * `py` must be an identifier refers to a `Python` value.
+///  * `py` must be an identifier refers to a `Python` value.
 ///   The function body will also have access to a `Python` variable of this name.
-/// * `f` must be an identifier.
-/// * The function return type must be `PyResult<T>` for some `T` that
+///  * `f` must be an identifier.
+///  * The function return type must be `PyResult<T>` for some `T` that
 ///   implements `ToPyObject`.
 ///
 /// # Example


### PR DESCRIPTION
Grepped the whole project, fixed with `sed -i` automatically. Fine for now.

In Markdown lists must be either separated from previous paragraph with extra blank line, or be indented with extra spaces at the beginning of each list item. 