### PR TITLE
remove usages of try! macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ use cpython::{PyResult, Python};
 // add bindings to the generated python module
 // N.B: names: "librust2py" must be the name of the `.so` or `.pyd` file
 py_module_initializer!(librust2py, initlibrust2py, PyInit_librust2py, |py, m| {
-    try!(m.add(py, "__doc__", "This module is implemented in Rust."));
-    try!(m.add(py, "sum_as_string", py_fn!(py, sum_as_string_py(a: i64, b:i64))));
+    m.add(py, "__doc__", "This module is implemented in Rust.")?;
+    m.add(py, "sum_as_string", py_fn!(py, sum_as_string_py(a: i64, b:i64)))?;
     Ok(())
 });
 

--- a/extensions/tests/btree.rs
+++ b/extensions/tests/btree.rs
@@ -6,8 +6,8 @@ use cpython::{PyObject, PyResult};
 use std::{cell, cmp, collections};
 
 py_module_initializer!(btree, initbtree, PyInit_btree, |py, m| {
-    try!(m.add(py, "__doc__", "Rust BTreeSet for Python."));
-    try!(m.add_class::<BTreeSet>(py));
+    m.add(py, "__doc__", "Rust BTreeSet for Python.")?;
+    m.add_class::<BTreeSet>(py)?;
     Ok(())
 });
 

--- a/extensions/tests/custom_class.rs
+++ b/extensions/tests/custom_class.rs
@@ -5,8 +5,8 @@
 use cpython::{PyObject, PyResult};
 
 py_module_initializer!(custom_class, initcustom_class, PyInit_custom_class, |py, m| {
-    try!(m.add(py, "__doc__", "Module documentation string"));
-    try!(m.add_class::<MyType>(py));
+    m.add(py, "__doc__", "Module documentation string")?;
+    m.add_class::<MyType>(py)?;
     Ok(())
 });
 

--- a/extensions/tests/hello.rs
+++ b/extensions/tests/hello.rs
@@ -5,9 +5,9 @@
 use cpython::{PyObject, PyResult, Python, PyTuple, PyDict};
 
 py_module_initializer!(hello, inithello, PyInit_hello, |py, m| {
-    try!(m.add(py, "__doc__", "Module documentation string"));
-    try!(m.add(py, "run", py_fn!(py, run(*args, **kwargs))));
-    try!(m.add(py, "val", py_fn!(py, val())));
+    m.add(py, "__doc__", "Module documentation string")?;
+    m.add(py, "run", py_fn!(py, run(*args, **kwargs)))?;
+    m.add(py, "val", py_fn!(py, val()))?;
     Ok(())
 });
 

--- a/python3-sys/build.rs
+++ b/python3-sys/build.rs
@@ -14,11 +14,11 @@ struct PythonVersion {
 
 impl fmt::Display for PythonVersion {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        try!(self.major.fmt(f));
-        try!(f.write_str("."));
+        self.major.fmt(f)?;
+        f.write_str(".")?;
         match self.minor {
-            Some(minor) => try!(minor.fmt(f)),
-            None => try!(f.write_str("*"))
+            Some(minor) => minor.fmt(f)?,
+            None => f.write_str("*")?
         };
         Ok(())
     }
@@ -34,7 +34,7 @@ static NEWLINE_SEQUENCE: &'static str = "\r\n";
 #[cfg(not(target_os="windows"))]
 static NEWLINE_SEQUENCE: &'static str = "\n";
 
-// A list of python interpreter compile-time preprocessor defines that 
+// A list of python interpreter compile-time preprocessor defines that
 // we will pick up and pass to rustc via --cfg=py_sys_config={varname};
 // this allows using them conditional cfg attributes in the .rs files, so
 //
@@ -44,7 +44,7 @@ static NEWLINE_SEQUENCE: &'static str = "\n";
 //
 // see Misc/SpecialBuilds.txt in the python source for what these mean.
 //
-// (hrm, this is sort of re-implementing what distutils does, except 
+// (hrm, this is sort of re-implementing what distutils does, except
 // by passing command line args instead of referring to a python.h)
 #[cfg(not(target_os="windows"))]
 static SYSCONFIG_FLAGS: [&'static str; 7] = [
@@ -58,15 +58,15 @@ static SYSCONFIG_FLAGS: [&'static str; 7] = [
 ];
 
 static SYSCONFIG_VALUES: [&'static str; 1] = [
-    // cfg doesn't support flags with values, just bools - so flags 
-    // below are translated into bools as {varname}_{val} 
+    // cfg doesn't support flags with values, just bools - so flags
+    // below are translated into bools as {varname}_{val}
     //
     // for example, Py_UNICODE_SIZE_2 or Py_UNICODE_SIZE_4
     "Py_UNICODE_SIZE" // note - not present on python 3.3+, which is always wide
 ];
 
 /// Examine python's compile flags to pass to cfg by launching
-/// the interpreter and printing variables of interest from 
+/// the interpreter and printing variables of interest from
 /// sysconfig.get_config_vars.
 #[cfg(not(target_os="windows"))]
 fn get_config_vars(python_path: &String) -> Result<HashMap<String, String>, String>  {
@@ -74,7 +74,7 @@ fn get_config_vars(python_path: &String) -> Result<HashMap<String, String>, Stri
 config = sysconfig.get_config_vars();".to_owned();
 
     for k in SYSCONFIG_FLAGS.iter().chain(SYSCONFIG_VALUES.iter()) {
-        script.push_str(&format!("print(config.get('{}', {}))", k, 
+        script.push_str(&format!("print(config.get('{}', {}))", k,
             if is_value(k) { "None" } else { "0" } ));
         script.push_str(";");
     }
@@ -82,9 +82,9 @@ config = sysconfig.get_config_vars();".to_owned();
     let mut cmd = Command::new(python_path);
     cmd.arg("-c").arg(script);
 
-    let out = try!(cmd.output().map_err(|e| {
+    let out = cmd.output().map_err(|e| {
         format!("failed to run python interpreter `{:?}`: {}", cmd, e)
-    }));
+    })?;
 
     if !out.status.success() {
         let stderr = String::from_utf8(out.stderr).unwrap();
@@ -114,7 +114,7 @@ config = sysconfig.get_config_vars();".to_owned();
 #[cfg(target_os="windows")]
 fn get_config_vars(_: &String) -> Result<HashMap<String, String>, String> {
     // sysconfig is missing all the flags on windows, so we can't actually
-    // query the interpreter directly for its build flags. 
+    // query the interpreter directly for its build flags.
     //
     // For the time being, this is the flags as defined in the python source's
     // PC\pyconfig.h. This won't work correctly if someone has built their
@@ -130,7 +130,7 @@ fn get_config_vars(_: &String) -> Result<HashMap<String, String>, String> {
     // a specially named pythonXX_d.exe and pythonXX_d.dll when you build the
     // Debug configuration, which this script doesn't currently support anyway.
     // map.insert("Py_DEBUG", "1");
-    
+
     // Uncomment these manually if your python was built with these and you want
     // the cfg flags to be set in rust.
     //
@@ -169,9 +169,9 @@ fn run_python_script(interpreter: &str, script: &str) -> Result<String, String> 
     let mut cmd = Command::new(interpreter);
     cmd.arg("-c").arg(script);
 
-    let out = try!(cmd.output().map_err(|e| {
+    let out = cmd.output().map_err(|e| {
         format!("failed to run python interpreter `{:?}`: {}", cmd, e)
-    }));
+    })?;
 
     if !out.status.success() {
         let stderr = String::from_utf8(out.stderr).unwrap();
@@ -203,14 +203,14 @@ fn get_macos_linkmodel() -> Result<String, String> {
 
 #[cfg(target_os="macos")]
 fn get_rustc_link_lib(_: &PythonVersion, ld_version: &str, _: bool) -> Result<String, String> {
-    // os x can be linked to a framework or static or dynamic, and 
+    // os x can be linked to a framework or static or dynamic, and
     // Py_ENABLE_SHARED is wrong; framework means shared library
     match get_macos_linkmodel().unwrap().as_ref() {
         "static" => Ok(format!("cargo:rustc-link-lib=static=python{}",
             ld_version)),
         "shared" => Ok(format!("cargo:rustc-link-lib=python{}",
             ld_version)),
-        "framework" => Ok(format!("cargo:rustc-link-lib=python{}", 
+        "framework" => Ok(format!("cargo:rustc-link-lib=python{}",
             ld_version)),
         other => Err(format!("unknown linkmodel {}", other))
     }
@@ -232,7 +232,7 @@ fn get_interpreter_version(line: &str) -> Result<PythonVersion, String> {
 #[cfg(target_os="windows")]
 fn get_rustc_link_lib(version: &PythonVersion, _: &str, _: bool) -> Result<String, String> {
     // Py_ENABLE_SHARED doesn't seem to be present on windows.
-    Ok(format!("cargo:rustc-link-lib=pythonXY:python{}{}", version.major, 
+    Ok(format!("cargo:rustc-link-lib=pythonXY:python{}{}", version.major,
         match version.minor {
             Some(minor) => minor.to_string(),
             None => "".to_owned()
@@ -256,7 +256,7 @@ fn find_interpreter_and_get_config(expected_version: &PythonVersion) ->
     if let Some(sys_executable) = env::var_os("PYTHON_SYS_EXECUTABLE") {
         let interpreter_path = sys_executable.to_str()
             .expect("Unable to get PYTHON_SYS_EXECUTABLE value");
-        let (executable, interpreter_version, lines) = try!(get_config_from_interpreter(interpreter_path));
+        let (executable, interpreter_version, lines) = get_config_from_interpreter(interpreter_path)?;
         if matching_version(expected_version, &interpreter_version) {
             return Ok((interpreter_version, executable.to_owned(), lines));
         } else {
@@ -269,24 +269,24 @@ fn find_interpreter_and_get_config(expected_version: &PythonVersion) ->
     }
     {
         let (executable, interpreter_version, lines) =
-            try!(get_config_from_interpreter("python"));
+            get_config_from_interpreter("python")?;
         if matching_version(expected_version, &interpreter_version) {
             return Ok((interpreter_version, executable.to_owned(), lines));
         }
     }
     {
         let major_interpreter_path = &format!("python{}", expected_version.major);
-        let (executable, interpreter_version, lines) = try!(get_config_from_interpreter(
-            major_interpreter_path));
+        let (executable, interpreter_version, lines) = get_config_from_interpreter(
+            major_interpreter_path)?;
         if matching_version(expected_version, &interpreter_version) {
             return Ok((interpreter_version, executable.to_owned(), lines));
         }
     }
     if let Some(minor) = expected_version.minor {
-        let minor_interpreter_path = &format!("python{}.{}", 
+        let minor_interpreter_path = &format!("python{}.{}",
             expected_version.major, minor);
-        let (executable, interpreter_version, lines) = try!(get_config_from_interpreter(
-            minor_interpreter_path));
+        let (executable, interpreter_version, lines) = get_config_from_interpreter(
+            minor_interpreter_path)?;
         if matching_version(expected_version, &interpreter_version) {
             return Ok((interpreter_version, executable.to_owned(), lines));
         }
@@ -303,11 +303,11 @@ print(sysconfig.get_config_var('LIBDIR')); \
 print(sysconfig.get_config_var('Py_ENABLE_SHARED')); \
 print(sysconfig.get_config_var('LDVERSION') or '%s%s' % (sysconfig.get_config_var('py_version_short'), sysconfig.get_config_var('DEBUG_EXT') or '')); \
 print(sys.exec_prefix);";
-    let out = try!(run_python_script(interpreter, script));
+    let out = run_python_script(interpreter, script)?;
     let mut lines: Vec<String> = out.split(NEWLINE_SEQUENCE).map(|line| line.to_owned()).collect();
     let executable = lines.remove(0);
     let interpreter_version = lines.remove(0);
-    let interpreter_version = try!(get_interpreter_version(&interpreter_version));
+    let interpreter_version = get_interpreter_version(&interpreter_version)?;
     Ok((executable, interpreter_version, lines))
 }
 
@@ -316,8 +316,8 @@ print(sys.exec_prefix);";
 ///
 /// Note that if the python doesn't satisfy expected_version, this will error.
 fn configure_from_path(expected_version: &PythonVersion) -> Result<String, String> {
-    let (interpreter_version, interpreter_path, lines) = 
-        try!(find_interpreter_and_get_config(expected_version));
+    let (interpreter_version, interpreter_path, lines) =
+        find_interpreter_and_get_config(expected_version)?;
     let libpath: &str = &lines[0];
     let enable_shared: &str = &lines[1];
     let ld_version: &str = &lines[2];
@@ -357,7 +357,7 @@ fn configure_from_path(expected_version: &PythonVersion) -> Result<String, Strin
 fn version_from_env() -> Result<PythonVersion, String> {
     let re = Regex::new(r"CARGO_FEATURE_PYTHON_(\d+)(_(\d+))?").unwrap();
     // sort env::vars so we get more explicit version specifiers first
-    // so if the user passes e.g. the python-3 feature and the python-3-5 
+    // so if the user passes e.g. the python-3 feature and the python-3-5
     // feature, python-3-5 takes priority.
     let mut vars = env::vars().collect::<Vec<_>>();
     vars.sort_by(|a, b| b.cmp(a));
@@ -378,15 +378,15 @@ fn version_from_env() -> Result<PythonVersion, String> {
 }
 
 fn main() {
-    // 1. Setup cfg variables so we can do conditional compilation in this 
-    // library based on the python interpeter's compilation flags. This is 
+    // 1. Setup cfg variables so we can do conditional compilation in this
+    // library based on the python interpeter's compilation flags. This is
     // necessary for e.g. matching the right unicode and threading interfaces.
     //
     // This locates the python interpreter based on the PATH, which should
     // work smoothly with an activated virtualenv.
     //
-    // If you have troubles with your shell accepting '.' in a var name, 
-    // try using 'env' (sorry but this isn't our fault - it just has to 
+    // If you have troubles with your shell accepting '.' in a var name,
+    // try using 'env' (sorry but this isn't our fault - it just has to
     // match the pkg-config package name, which is going to have a . in it).
     let version = version_from_env().unwrap();
     let python_interpreter_path = configure_from_path(&version).unwrap();
@@ -404,9 +404,9 @@ fn main() {
         }
     }
 
-    // 2. Export python interpreter compilation flags as cargo variables that 
+    // 2. Export python interpreter compilation flags as cargo variables that
     // will be visible to dependents. All flags will be available to dependent
-    // build scripts in the environment variable DEP_PYTHON27_PYTHON_FLAGS as 
+    // build scripts in the environment variable DEP_PYTHON27_PYTHON_FLAGS as
     // comma separated list; each item in the list looks like
     //
     // {VAL,FLAG}_{flag_name}=val;
@@ -415,7 +415,7 @@ fn main() {
     // VAL indicates it can take on any value
     //
     // rust-cypthon/build.rs contains an example of how to unpack this data
-    // into cfg flags that replicate the ones present in this library, so 
+    // into cfg flags that replicate the ones present in this library, so
     // you can use the same cfg syntax.
     let flags: String = config_map.iter().fold("".to_owned(), |memo, (key, val)| {
         if is_value(key) {
@@ -426,7 +426,7 @@ fn main() {
             memo
         }
     });
-    println!("cargo:python_flags={}", 
+    println!("cargo:python_flags={}",
         if flags.len() > 0 { &flags[..flags.len()-1] } else { "" });
 
     // 3. Export Python interpreter path as a Cargo variable so dependent build

--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -92,7 +92,7 @@ pub fn parse_args(
     if used_keywords != nkeywords {
         // check for extraneous keyword arguments
         for (key, _value) in kwargs.unwrap().items(py) {
-            let key = try!(try!(key.cast_as::<PyString>(py)).to_string(py));
+            let key = key.cast_as::<PyString>(py)?.to_string(py)?;
             if !params.iter().any(|p| p.name == key) {
                 return Err(err::PyErr::new::<exc::TypeError, _>(py,
                     format!("'{}' is an invalid keyword argument for this function",

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -63,9 +63,9 @@ pub trait ToPyObject {
     //   -> with_borrowed_ptr() just forwards to the closure
     // 3) input is &str, int, ...
     //   -> to_py_object() allocates new Python object; FFI call happens; release_ref() calls Py_DECREF()
-    
+
     // FFI functions that steal a reference will use:
-    //   let input = try!(input.into_py_object()); ffi::Call(input.steal_ptr())
+    //   let input = input.into_py_object()?; ffi::Call(input.steal_ptr())
     // 1) input is &PyObject
     //   -> into_py_object() calls Py_INCREF
     // 2) input is PyObject
@@ -80,7 +80,7 @@ py_impl_to_py_object_for_python_object!(PyObject);
 ///
 /// Normal usage is through the `PyObject::extract` helper method:
 /// ```let obj: PyObject = ...;
-/// let value = try!(obj.extract::<TargetType>(py));
+/// let value = obj.extract::<TargetType>(py)?;
 /// ```
 ///
 /// TODO: update this documentation
@@ -138,7 +138,7 @@ where T: PythonObjectWithCheckedDowncast
 
     #[inline]
     fn extract(py: Python, obj: &'prepared Self::Prepared) -> PyResult<T> {
-        Ok(try!(obj.clone_ref(py).cast_into(py)))
+        Ok(obj.clone_ref(py).cast_into(py)?)
     }
 }
 */
@@ -208,7 +208,7 @@ where T: ExtractPyObject<'prepared>
         if obj.as_ptr() == unsafe { ffi::Py_None() } {
             Ok(None)
         } else {
-            Ok(Some(try!(T::prepare_extract(py, obj))))
+            Ok(Some(T::prepare_extract(py, obj)?))
         }
     }
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -426,7 +426,7 @@ pub unsafe fn result_cast_from_owned_ptr<T>(py : Python, p : *mut ffi::PyObject)
     if p.is_null() {
         Err(PyErr::fetch(py))
     } else {
-        Ok(try!(PyObject::from_owned_ptr(py, p).cast_into(py)))
+        Ok(PyObject::from_owned_ptr(py, p).cast_into(py)?)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //! default-features = false
 //! features = ["python27-sys"]
 //! ```
-//! 
+//!
 //! # Error Handling
 //! The vast majority of operations in this library will return `PyResult<...>`.
 //! This is an alias for the type `Result<..., PyErr>`.
@@ -171,14 +171,14 @@ macro_rules! py_impl_from_py_object_for_python_object {
             #[inline]
             fn extract(py: $crate::Python, obj: &'source $crate::PyObject) -> $crate::PyResult<$T> {
                 use $crate::PyClone;
-                Ok(try!(obj.clone_ref(py).cast_into::<$T>(py)))
+                Ok(obj.clone_ref(py).cast_into::<$T>(py)?)
             }
         }
 
         impl <'source> $crate::FromPyObject<'source> for &'source $T {
             #[inline]
             fn extract(py: $crate::Python, obj: &'source $crate::PyObject) -> $crate::PyResult<&'source $T> {
-                Ok(try!(obj.cast_as::<$T>(py)))
+                Ok(obj.cast_as::<$T>(py)?)
             }
         }
     }

--- a/src/objects/boolobject.rs
+++ b/src/objects/boolobject.rs
@@ -45,7 +45,7 @@ impl ToPyObject for bool {
 ///
 /// Fails with `TypeError` if the input is not a Python `bool`.
 extract!(obj to bool; py => {
-    Ok(try!(obj.cast_as::<PyBool>(py)).is_true())
+    Ok(obj.cast_as::<PyBool>(py)?.is_true())
 });
 
 #[cfg(test)]

--- a/src/objects/module.rs
+++ b/src/objects/module.rs
@@ -65,7 +65,7 @@ impl PyModule {
             let slice = CStr::from_ptr(ptr).to_bytes();
             match std::str::from_utf8(slice) {
                 Ok(s) => Ok(s),
-                Err(e) => Err(PyErr::from_instance(py, try!(exc::UnicodeDecodeError::new_utf8(py, slice, e))))
+                Err(e) => Err(PyErr::from_instance(py, exc::UnicodeDecodeError::new_utf8(py, slice, e)?))
             }
         }
     }
@@ -113,7 +113,7 @@ impl PyModule {
     pub fn call<A>(&self, py: Python, name: &str, args: A, kwargs: Option<&PyDict>) -> PyResult<PyObject>
         where A: ToPyObject<ObjectType=PyTuple>
     {
-        try!(self.as_object().getattr(py, name)).call(py, args, kwargs)
+        self.as_object().getattr(py, name)?.call(py, args, kwargs)
     }
 
     /// Adds a member to the module.

--- a/src/objects/num.rs
+++ b/src/objects/num.rs
@@ -154,7 +154,7 @@ macro_rules! int_fits_larger_int(
         }
 
         extract!(obj to $rust_type; py => {
-            let val = try!(obj.extract::<$larger_type>(py));
+            let val = obj.extract::<$larger_type>(py)?;
             match cast::<$larger_type, $rust_type>(val) {
                 Some(v) => Ok(v),
                 None => Err(overflow_error(py))
@@ -216,7 +216,7 @@ macro_rules! int_convert_u64_or_i64 (
                             None => Err(overflow_error(py))
                         }
                     } else {
-                        let num = try!(err::result_from_owned_ptr(py, ffi::PyNumber_Long(ptr)));
+                        let num = err::result_from_owned_ptr(py, ffi::PyNumber_Long(ptr))?;
                         err_if_invalid_value(py, !0, $pylong_as_ull_or_ull(num.as_ptr()))
                     }
                 }
@@ -229,7 +229,7 @@ macro_rules! int_convert_u64_or_i64 (
                     if ffi::PyLong_Check(ptr) != 0 {
                         err_if_invalid_value(py, !0, $pylong_as_ull_or_ull(ptr))
                     } else {
-                        let num = try!(err::result_from_owned_ptr(py, ffi::PyNumber_Long(ptr)));
+                        let num = err::result_from_owned_ptr(py, ffi::PyNumber_Long(ptr))?;
                         err_if_invalid_value(py, !0, $pylong_as_ull_or_ull(num.as_ptr()))
                     }
                 }
@@ -298,7 +298,7 @@ impl ToPyObject for f32 {
 }
 
 extract!(obj to f32; py => {
-    Ok(try!(obj.extract::<f64>(py)) as f32)
+    Ok(obj.extract::<f64>(py)? as f32)
 });
 
 #[cfg(test)]
@@ -348,7 +348,7 @@ mod test {
         assert_eq!(v as u64, obj.extract::<u64>(py).unwrap());
         assert!(obj.extract::<i32>(py).is_err());
     }
-    
+
     #[test]
     fn test_i64_max() {
         let gil = Python::acquire_gil();
@@ -359,7 +359,7 @@ mod test {
         assert_eq!(v as u64, obj.extract::<u64>(py).unwrap());
         assert!(obj.extract::<u32>(py).is_err());
     }
-    
+
     #[test]
     fn test_i64_min() {
         let gil = Python::acquire_gil();
@@ -370,7 +370,7 @@ mod test {
         assert!(obj.extract::<i32>(py).is_err());
         assert!(obj.extract::<u64>(py).is_err());
     }
-    
+
     #[test]
     fn test_u64_max() {
         let gil = Python::acquire_gil();

--- a/src/objects/sequence.rs
+++ b/src/objects/sequence.rs
@@ -113,7 +113,7 @@ impl PySequence {
     /// Python statement `del o[i]`
     #[inline]
     pub fn del_item(&self, py: Python, i: isize) -> PyResult<()> {
-        unsafe { 
+        unsafe {
             err::error_on_minusone(py,
                 ffi::PySequence_DelItem(self.as_ptr(), i as Py_ssize_t))
         }
@@ -133,7 +133,7 @@ impl PySequence {
     /// equivalent of the Python statement `del o[i1:i2]`
     #[inline]
     pub fn del_slice(&self, py: Python, i1: isize, i2: isize) -> PyResult<()> {
-        unsafe { 
+        unsafe {
             err::error_on_minusone(py,
                 ffi::PySequence_DelSlice(self.as_ptr(), i1 as Py_ssize_t, i2 as Py_ssize_t))
         }
@@ -250,11 +250,11 @@ impl <'source, T> FromPyObject<'source> for Vec<T>
 fn extract_sequence<T>(py: Python, obj: &PyObject) -> PyResult<Vec<T>>
     where for<'a> T: FromPyObject<'a>
 {
-    let seq = try!(obj.cast_as::<PySequence>(py));
+    let seq = obj.cast_as::<PySequence>(py)?;
     let mut v = Vec::new();
-    for item in try!(seq.iter(py)) {
-        let item = try!(item);
-        v.push(try!(T::extract(py, &item)));
+    for item in seq.iter(py)? {
+        let item = item?;
+        v.push(T::extract(py, &item)?);
         item.release_ref(py);
     }
     Ok(v)
@@ -508,7 +508,7 @@ mod test {
         let v: Vec<i32> = py.eval("range(1, 5)", None, None).unwrap().extract(py).unwrap();
         assert!(v == [1, 2, 3, 4]);
     }
-    
+
     #[test]
     fn test_extract_bytearray_to_vec() {
         let gil = Python::acquire_gil();

--- a/src/objects/tuple.rs
+++ b/src/objects/tuple.rs
@@ -116,11 +116,11 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
 
     impl <'s, $($T: FromPyObject<'s>),+> FromPyObject<'s> for ($($T,)+) {
         fn extract(py: Python, obj: &'s PyObject) -> PyResult<Self> {
-            let t = try!(obj.cast_as::<PyTuple>(py));
+            let t = obj.cast_as::<PyTuple>(py)?;
             let slice = t.as_slice(py);
             if slice.len() == $length {
                 Ok((
-                    $( try!(slice[$n].extract::<$T>(py)), )+
+                    $( slice[$n].extract::<$T>(py)?, )+
                 ))
             } else {
                 Err(wrong_tuple_length(py, t, $length))
@@ -171,7 +171,7 @@ impl ToPyObject for NoArgs {
 /// Returns `Ok(NoArgs)` if the input is an empty Python tuple.
 /// Otherwise, returns an error.
 extract!(obj to NoArgs; py => {
-    let t = try!(obj.cast_as::<PyTuple>(py));
+    let t = obj.cast_as::<PyTuple>(py)?;
     if t.len(py) == 0 {
         Ok(NoArgs)
     } else {

--- a/src/py_class/gc.rs
+++ b/src/py_class/gc.rs
@@ -166,7 +166,7 @@ impl <T> Traversable for Option<T> where T: Traversable {
 impl <T> Traversable for Vec<T> where T: Traversable {
     fn traverse(&self, py: Python, visit: VisitProc) -> Result<(), TraverseError> {
         for val in self {
-            try!(val.traverse(py, visit));
+            val.traverse(py, visit)?;
         }
         Ok(())
     }

--- a/src/py_class/members.rs
+++ b/src/py_class/members.rs
@@ -52,10 +52,10 @@ macro_rules! py_class_init_members {
         $( {
             // keep $init out of unsafe block; it might contain user code
             let init = $init;
-            let descriptor = try!(unsafe {
+            let descriptor = unsafe {
                 $crate::py_class::members::TypeMember::<$class>::into_descriptor(init, $py, &mut $type_object)
-            });
-            try!(dict.set_item($py, stringify!($name), descriptor));
+            }?;
+            dict.set_item($py, stringify!($name), descriptor)?;
         })*
         unsafe {
             assert!($type_object.tp_dict.is_null());

--- a/src/py_class/py_class.rs
+++ b/src/py_class/py_class.rs
@@ -191,7 +191,7 @@ py_class!(class ClassWithGCSupport |py| {
 
     def __traverse__(&self, visit) {
         if let Some(ref obj) = *self.obj(py).borrow() {
-            try!(visit.call(obj))
+            visit.call(obj)?
         }
         Ok(())
     }

--- a/src/py_class/py_class_impl.py
+++ b/src/py_class/py_class_impl.py
@@ -117,7 +117,7 @@ base_case = '''
                     ( $( $data_name, )* ): Self::InitType
                 ) -> $crate::PyResult<$crate::PyObject>
                 {
-                    let obj = try!(<$base_type as $crate::py_class::BaseObject>::alloc(py, ty, ()));
+                    let obj = <$base_type as $crate::py_class::BaseObject>::alloc(py, ty, ())?;
                     $( $crate::py_class::data_init::<$data_ty>(py, &obj, $data_offset, $data_name); )*
                     Ok(obj)
                 }
@@ -132,11 +132,11 @@ base_case = '''
         py_coerce_item! {
             impl $class {
                 fn create_instance(py: $crate::Python $( , $data_name : $data_ty )* ) -> $crate::PyResult<$class> {
-                    let obj = try!(unsafe {
+                    let obj = unsafe {
                         <$class as $crate::py_class::BaseObject>::alloc(
                             py, &py.get_type::<$class>(), ( $($data_name,)* )
                         )
-                    });
+                    }?;
                     return Ok($class { _unsafe_inner: obj });
 
                     // hide statics in create_instance to avoid name conflicts

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -109,7 +109,7 @@ macro_rules! py_class_impl {
                     ( $( $data_name, )* ): Self::InitType
                 ) -> $crate::PyResult<$crate::PyObject>
                 {
-                    let obj = try!(<$base_type as $crate::py_class::BaseObject>::alloc(py, ty, ()));
+                    let obj = <$base_type as $crate::py_class::BaseObject>::alloc(py, ty, ())?;
                     $( $crate::py_class::data_init::<$data_ty>(py, &obj, $data_offset, $data_name); )*
                     Ok(obj)
                 }
@@ -124,11 +124,11 @@ macro_rules! py_class_impl {
         py_coerce_item! {
             impl $class {
                 fn create_instance(py: $crate::Python $( , $data_name : $data_ty )* ) -> $crate::PyResult<$class> {
-                    let obj = try!(unsafe {
+                    let obj = unsafe {
                         <$class as $crate::py_class::BaseObject>::alloc(
                             py, &py.get_type::<$class>(), ( $($data_name,)* )
                         )
-                    });
+                    }?;
                     return Ok($class { _unsafe_inner: obj });
 
                     // hide statics in create_instance to avoid name conflicts

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -109,7 +109,7 @@ macro_rules! py_class_impl {
                     ( $( $data_name, )* ): Self::InitType
                 ) -> $crate::PyResult<$crate::PyObject>
                 {
-                    let obj = try!(<$base_type as $crate::py_class::BaseObject>::alloc(py, ty, ()));
+                    let obj = <$base_type as $crate::py_class::BaseObject>::alloc(py, ty, ())?;
                     $( $crate::py_class::data_init::<$data_ty>(py, &obj, $data_offset, $data_name); )*
                     Ok(obj)
                 }
@@ -124,11 +124,11 @@ macro_rules! py_class_impl {
         py_coerce_item! {
             impl $class {
                 fn create_instance(py: $crate::Python $( , $data_name : $data_ty )* ) -> $crate::PyResult<$class> {
-                    let obj = try!(unsafe {
+                    let obj = unsafe {
                         <$class as $crate::py_class::BaseObject>::alloc(
                             py, &py.get_type::<$class>(), ( $($data_name,)* )
                         )
-                    });
+                    }?;
                     return Ok($class { _unsafe_inner: obj });
 
                     // hide statics in create_instance to avoid name conflicts


### PR DESCRIPTION
while starting to look at https://github.com/dgrunwald/rust-cpython/issues/159 I noticed an enormous amount of try! macro usages.  The docs for [try](https://doc.rust-lang.org/std/macro.try.html) recommend using `?` instead. I thought I might take a look at this before taking a stab at a bigger pull for the 1.30 macro updates