### PR TITLE
build.rs: Be resilient to the absence of "python" executable

### DIFF
--- a/python27-sys/build.rs
+++ b/python27-sys/build.rs
@@ -277,28 +277,19 @@ fn find_interpreter_and_get_config(expected_version: &PythonVersion) ->
                                interpreter_version));
         }
     }
-    {
-        let (executable, interpreter_version, lines) =
-            get_config_from_interpreter("python")?;
-        if matching_version(expected_version, &interpreter_version) {
-            return Ok((interpreter_version, executable.to_owned(), lines));
-        }
-    }
-    {
-        let major_interpreter_path = &format!("python{}", expected_version.major);
-        let (executable, interpreter_version, lines) = get_config_from_interpreter(
-            major_interpreter_path)?;
-        if matching_version(expected_version, &interpreter_version) {
-            return Ok((interpreter_version, executable.to_owned(), lines));
-        }
-    }
+    let mut possible_names = vec![
+        "python".to_string(),
+        format!("python{}", expected_version.major),
+    ];
     if let Some(minor) = expected_version.minor {
-        let minor_interpreter_path = &format!("python{}.{}",
-            expected_version.major, minor);
-        let (executable, interpreter_version, lines) = get_config_from_interpreter(
-            minor_interpreter_path)?;
-        if matching_version(expected_version, &interpreter_version) {
-            return Ok((interpreter_version, executable.to_owned(), lines));
+        possible_names.push(format!("python{}.{}", expected_version.major, minor));
+    }
+
+    for name in possible_names.iter() {
+        if let Some((executable, interpreter_version, lines)) = get_config_from_interpreter(name).ok() {
+            if matching_version(expected_version, &interpreter_version) {
+                return Ok((interpreter_version, executable.to_owned(), lines));
+            }
         }
     }
     Err(format!("No python interpreter found of version {}",

--- a/python3-sys/build.rs
+++ b/python3-sys/build.rs
@@ -267,28 +267,20 @@ fn find_interpreter_and_get_config(expected_version: &PythonVersion) ->
                                interpreter_version));
         }
     }
-    {
-        let (executable, interpreter_version, lines) =
-            get_config_from_interpreter("python")?;
-        if matching_version(expected_version, &interpreter_version) {
-            return Ok((interpreter_version, executable.to_owned(), lines));
-        }
-    }
-    {
-        let major_interpreter_path = &format!("python{}", expected_version.major);
-        let (executable, interpreter_version, lines) = get_config_from_interpreter(
-            major_interpreter_path)?;
-        if matching_version(expected_version, &interpreter_version) {
-            return Ok((interpreter_version, executable.to_owned(), lines));
-        }
-    }
+
+    let mut possible_names = vec![
+        "python".to_string(),
+        format!("python{}", expected_version.major),
+    ];
     if let Some(minor) = expected_version.minor {
-        let minor_interpreter_path = &format!("python{}.{}",
-            expected_version.major, minor);
-        let (executable, interpreter_version, lines) = get_config_from_interpreter(
-            minor_interpreter_path)?;
-        if matching_version(expected_version, &interpreter_version) {
-            return Ok((interpreter_version, executable.to_owned(), lines));
+        possible_names.push(format!("python{}.{}", expected_version.major, minor));
+    }
+
+    for name in possible_names.iter() {
+        if let Some((executable, interpreter_version, lines)) = get_config_from_interpreter(name).ok() {
+            if matching_version(expected_version, &interpreter_version) {
+                return Ok((interpreter_version, executable.to_owned(), lines));
+            }
         }
     }
     Err(format!("No python interpreter found of version {}",


### PR DESCRIPTION
Fix extreme case where attempting to build on a machine which only has
"pythonX" or "pythonX.Y" executable.

Previously, if the "python" executable didn't exist on the system,
attempting to call get_config_from_interpreter("python")
resulted in the entire find_interpreter_and_get_config() function to
return Error.
With this change, the abscense of "python" executable will be ignored
and the other executable names will be attempted before giving up.