### PR TITLE
Add missing bindings

### DIFF
--- a/python3-sys/src/fileutils.rs
+++ b/python3-sys/src/fileutils.rs
@@ -1,0 +1,8 @@
+use libc::{c_char, size_t, wchar_t};
+
+#[cfg(not(Py_LIMITED_API))]
+#[cfg_attr(windows, link(name="pythonXY"))]
+extern "C" {
+    pub fn Py_DecodeLocale(arg: *const c_char, size: *mut size_t) -> *const wchar_t;
+    pub fn Py_EncodeLocale(text: *const wchar_t, error_pos: *mut size_t) -> *const c_char;
+}

--- a/python3-sys/src/import.rs
+++ b/python3-sys/src/import.rs
@@ -1,4 +1,4 @@
-use libc::{c_char, c_int, c_long};
+use libc::{c_char, c_int, c_long, c_uchar};
 use object::PyObject;
 
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
@@ -70,3 +70,17 @@ pub unsafe fn PyImport_ImportModuleEx(name: *const c_char,
      -> c_int;
 }
 
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[cfg(not(Py_LIMITED_API))]
+pub struct _frozen {
+    pub name: *const c_char,
+    pub code: *const c_uchar,
+    pub size: c_int,
+}
+
+#[cfg(not(Py_LIMITED_API))]
+#[cfg_attr(windows, link(name="pythonXY"))]
+extern "C" {
+    pub static mut PyImport_FrozenModules: *const _frozen;
+}

--- a/python3-sys/src/import.rs
+++ b/python3-sys/src/import.rs
@@ -66,7 +66,7 @@ pub unsafe fn PyImport_ImportModuleEx(name: *const c_char,
     // pub static mut PyNullImporter_Type: PyTypeObject; -- does not actually exist in shared library
 
     pub fn PyImport_AppendInittab(name: *const c_char,
-                                  initfunc: Option<extern "C" fn() -> *mut PyObject>)
+                                  initfunc: Option<unsafe extern "C" fn() -> *mut PyObject>)
      -> c_int;
 }
 

--- a/python3-sys/src/lib.rs
+++ b/python3-sys/src/lib.rs
@@ -38,6 +38,8 @@ pub use setobject::*;
 pub use methodobject::*;
 pub use moduleobject::*;
 pub use fileobject::*;
+#[cfg(Py_3_5)]
+pub use fileutils::*;
 pub use pycapsule::*;
 pub use traceback::*;
 pub use sliceobject::*;
@@ -153,7 +155,8 @@ mod eval; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod pystrtod; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 // mod pystrcmp; TODO nothing interesting for Rust?
 // mod dtoa; TODO excluded by PEP-384
-// mod fileutils; TODO no public functions?
+#[cfg(Py_3_5)]
+mod fileutils;
 // mod pyfpe; TODO probably not interesting for rust
 
 // Additional headers that are not exported by Python.h

--- a/python3-sys/src/pythonrun.rs
+++ b/python3-sys/src/pythonrun.rs
@@ -6,6 +6,8 @@ use pystate::PyThreadState;
 use pyarena::PyArena;
 
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" { // TODO: these moved to pylifecycle.h
+    #[cfg(Py_3_4)]
+    pub fn Py_SetStandardStreamEncoding(encoding: *const c_char, errors: *const c_char) -> c_int;
     pub fn Py_SetProgramName(arg1: *const wchar_t) -> ();
     pub fn Py_GetProgramName() -> *mut wchar_t;
     pub fn Py_SetPythonHome(arg1: *const wchar_t) -> ();

--- a/python3-sys/src/pythonrun.rs
+++ b/python3-sys/src/pythonrun.rs
@@ -15,6 +15,8 @@ use pyarena::PyArena;
     pub fn Py_Initialize() -> ();
     pub fn Py_InitializeEx(arg1: c_int) -> ();
     pub fn Py_Finalize() -> ();
+    #[cfg(Py_3_6)]
+    pub fn Py_FinalizeEx() -> c_int;
     pub fn Py_IsInitialized() -> c_int;
     pub fn Py_NewInterpreter() -> *mut PyThreadState;
     pub fn Py_EndInterpreter(arg1: *mut PyThreadState) -> ();


### PR DESCRIPTION
I've been playing around with Rust applications embedding Python 3 interpreters. There were some APIs missing from python3-sys that I found myself needing. The commits in this series introduce various APIs.

I'm not 100% confident I got some style things correct. But that's what review is for :)