### PR TITLE
Add "no-auto-initialize" feature to prevent call to prepare_freethreaded_python()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,20 @@ python-3-4 = ["python3-sys/python-3-4"]
 
 #pep-384 = ["python3-sys/pep-384"]
 
+# When set, do not call prepare_freethreaded_python() when calling
+# GILGuard::acquire(). This effectively prevents the crate from automatically
+# calling Py_Initialize() and other functions that attempt to automatically
+# initialize the Python interpreter.
+#
+# This feature can be useful for programs embedding Python, which can guarantee
+# Python interpreter initialization and don't need the automatic-by-default
+# behavior or don't want the behavior coded into this crate.
+#
+# The feature may also be necessary if this crate's code executes as part of
+# Python interpreter initialization, before the Py_Initialize() call completes.
+# This scenario should be rare.
+no-auto-initialize = []
+
 [workspace]
 members = ["python27-sys", "python3-sys", "extensions/hello"]
 

--- a/src/pythonrun.rs
+++ b/src/pythonrun.rs
@@ -111,7 +111,9 @@ impl GILGuard {
     /// If the Python runtime is not already initialized, this function will initialize it.
     /// See [prepare_freethreaded_python()](fn.prepare_freethreaded_python.html) for details.
     pub fn acquire() -> GILGuard {
-        ::pythonrun::prepare_freethreaded_python();
+        if !cfg!(feature = "no-auto-initialize") {
+            ::pythonrun::prepare_freethreaded_python();
+        }
         let gstate = unsafe { ffi::PyGILState_Ensure() }; // acquire GIL
         GILGuard { gstate: gstate, no_send: marker::PhantomData }
     }


### PR DESCRIPTION
When embedding a Python interpreter in a Rust program, the automatic call
to prepare_freethreaded_python() to initialize the Python interpreter was
causing me problems.

Specifically, I'm doing very dirty things where I've managed to modify the
code that runs as part of Python interpreter startup, before Py_Initialize()
completes. The code that runs is using this crate. That code results
in a call to PyObject::drop(), which calls Python::acquire_gil(),
which calls GILGuard::acquire(), which calls prepare_freethreaded_python(),
which calls Py_InitializeEx(), and leads to reentrant execution because
Py_IsInitialized() returns 0 since the initial call hasn't completed.
I've managed to trigger a Rust panic due to detected reentrancy. I've
also managed to trigger deadlock, apparently due to the 2nd Py_Initialize()
trying to acquire the GIL, which is held by the original Py_Initialize().

Taking a step back, prepare_freethreaded_python() is making assumptions about
how to initialize the Python interpreter, which may vary from what applications
embedding Python may want. At the end of the day, the automatic call to this
function is to prevent a footgun where a consumer of this crate may forget
to initialize the Python interpreter first.

This commit adds a disabled-by-default (for backwards compatibility) feature
to disable the call to prepare_freethreaded_python() and therefore disables
the automatic initialization of the Python interpreter. When enabling the
feature, my Rust code using this crate that runs as part of Py_Initialize()
no longer results in reentrancy or GIL deadlocks.