### PR TITLE
Use Rust docstring for __doc__ of instance methods

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -30,6 +30,10 @@ use err::{self, PyResult};
 #[doc(hidden)]
 macro_rules! py_method_def {
     ($name: expr, $flags: expr, $wrap: expr) => {{
+        py_method_def!($name, $flags, $wrap, "")
+    }};
+
+    ($name: expr, $flags: expr, $wrap: expr, $doc: expr) => {{
         static mut METHOD_DEF: $crate::_detail::ffi::PyMethodDef = $crate::_detail::ffi::PyMethodDef {
             //ml_name: bytes!(stringify!($name), "\0"),
             ml_name: 0 as *const $crate::_detail::libc::c_char,
@@ -38,12 +42,15 @@ macro_rules! py_method_def {
             ml_doc: 0 as *const $crate::_detail::libc::c_char
         };
         METHOD_DEF.ml_name = concat!($name, "\0").as_ptr() as *const _;
+        if !$doc.is_empty() {
+            METHOD_DEF.ml_doc = concat!($doc, "\0").as_ptr() as *const _;
+        }
         METHOD_DEF.ml_meth = Some(
             ::std::mem::transmute::<$crate::_detail::ffi::PyCFunctionWithKeywords,
                                   $crate::_detail::ffi::PyCFunction>($wrap)
         );
         &mut METHOD_DEF
-    }}
+    }};
 }
 
 /// Creates a Python callable object that invokes a Rust function.

--- a/src/py_class/members.rs
+++ b/src/py_class/members.rs
@@ -68,6 +68,10 @@ macro_rules! py_class_init_members {
 #[doc(hidden)]
 macro_rules! py_class_instance_method {
     ($py:ident, $class:ident :: $f:ident [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]) => {{
+        py_class_instance_method!($py, $class::$f, { "" } [ $( { $pname : $ptype = $detail } )* ])
+    }};
+
+    ($py:ident, $class:ident :: $f:ident, { $doc:expr } [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]) => {{
         unsafe extern "C" fn wrap_instance_method(
             slf: *mut $crate::_detail::ffi::PyObject,
             args: *mut $crate::_detail::ffi::PyObject,
@@ -89,7 +93,7 @@ macro_rules! py_class_instance_method {
                 })
         }
         unsafe {
-            let method_def = py_method_def!(_cpython__py_class__members__stringify!($f), 0, wrap_instance_method);
+            let method_def = py_method_def!(_cpython__py_class__members__stringify!($f), 0, wrap_instance_method, $doc);
             $crate::py_class::members::create_instance_method_descriptor::<$class>(method_def)
         }
     }}

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -1708,7 +1708,7 @@ macro_rules! py_class_impl {
     { { def __xor__ $($tail:tt)* } $( $stuff:tt )* } => {
         py_error! { "Invalid signature for binary numeric operator __xor__" }
     };
-    { {  def $name:ident (&$slf:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+    { { $(#[doc=$doc:expr])* def $name:ident (&$slf:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
         { $( $member_name:ident = $member_expr:expr; )* }
@@ -1721,10 +1721,10 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name = py_class_instance_method!{$py, $class::$name []};
+            $name = py_class_instance_method!{$py, $class::$name, { _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*) } []};
         }
     }};
-    { {  def $name:ident (&$slf:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+    { { $(#[doc=$doc:expr])* def $name:ident (&$slf:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
         { $( $member_name:ident = $member_expr:expr; )* }
@@ -1740,7 +1740,7 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name = py_argparse_parse_plist_impl!{py_class_instance_method {$py, $class::$name} [] ($($p)+,)};
+            $name = py_argparse_parse_plist_impl!{py_class_instance_method {$py, $class::$name, { _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*) }} [] ($($p)+,)};
         }
     }};
     { { @classmethod def $name:ident ($cls:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
@@ -1794,7 +1794,7 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name =
+            $name = 
             py_argparse_parse_plist!{
                 py_class_static_method {$py, $class::$name}
                 ($($p)*)

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -1708,7 +1708,7 @@ macro_rules! py_class_impl {
     { { def __xor__ $($tail:tt)* } $( $stuff:tt )* } => {
         py_error! { "Invalid signature for binary numeric operator __xor__" }
     };
-    { {  def $name:ident (&$slf:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+    { { $(#[doc=$doc:expr])* def $name:ident (&$slf:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
         { $( $member_name:ident = $member_expr:expr; )* }
@@ -1721,10 +1721,10 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name = py_class_instance_method!{$py, $class::$name []};
+            $name = py_class_instance_method!{$py, $class::$name, { _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*) } []};
         }
     }};
-    { {  def $name:ident (&$slf:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+    { { $(#[doc=$doc:expr])* def $name:ident (&$slf:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
         { $( $member_name:ident = $member_expr:expr; )* }
@@ -1740,7 +1740,7 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name = py_argparse_parse_plist_impl!{py_class_instance_method {$py, $class::$name} [] ($($p)+,)};
+            $name = py_argparse_parse_plist_impl!{py_class_instance_method {$py, $class::$name, { _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*) }} [] ($($p)+,)};
         }
     }};
     { { @classmethod def $name:ident ($cls:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
@@ -1794,7 +1794,7 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name =
+            $name = 
             py_argparse_parse_plist!{
                 py_class_static_method {$py, $class::$name}
                 ($($p)*)


### PR DESCRIPTION
This patch allows `__doc__` of instance methods to be specified using Rust
docstrings, like:

    py_class!(... {
        ///Write something.
        ///Second line.
        def foo(&self, ...) -> ... {
            ...
        }
    }

Then `instance.foo.__doc__` would be `"Write something.\nSecond line.\n"` in the
Python world.

Under the hood, Rust translates `/// foo` to `#[doc="foo"]` automatically. So
they can be matched using macros. See https://doc.rust-lang.org/beta/rustdoc/the-doc-attribute.html