### PR TITLE
Make macros work with rust 2018

### DIFF
--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -140,14 +140,14 @@ pub fn parse_args(
 /// so `return` statements might behave unexpectedly in this case. (this only affects direct use
 /// of `py_argparse!`; `py_fn!` is unaffected as the body there is always in a separate function
 /// from the generated argument-parsing code).
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! py_argparse {
     ($py:expr, $fname:expr, $args:expr, $kwargs:expr, $plist:tt $body:block) => {
         py_argparse_parse_plist! { py_argparse_impl { $py, $fname, $args, $kwargs, $body, } $plist }
     };
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_argparse_parse_plist {
     // Parses a parameter-list into a format more suitable for consumption by Rust macros.
@@ -167,7 +167,7 @@ macro_rules! py_argparse_parse_plist {
     };
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_argparse_parse_plist_impl {
     // TT muncher macro that does the main work for py_argparse_parse_plist!.
@@ -290,7 +290,7 @@ macro_rules! py_argparse_parse_plist_impl {
 
 // The main py_argparse!() macro, except that it expects the parameter-list
 // in the output format of py_argparse_parse_plist!().
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_argparse_impl {
     // special case: function signature is (*args, **kwargs),
@@ -337,7 +337,7 @@ macro_rules! py_argparse_impl {
 }
 
 // Like py_argparse_impl!(), but accepts `*mut ffi::PyObject` for $args and $kwargs.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_argparse_raw {
     ($py:ident, $fname:expr, $args:expr, $kwargs:expr, $plist:tt $body:block) => {{
@@ -379,7 +379,7 @@ macro_rules! py_argparse_param_description {
     );
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_argparse_extract {
     // base case

--- a/src/err.rs
+++ b/src/err.rs
@@ -59,7 +59,7 @@ fn main() {
 }
 ```
 */
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! py_exception {
     ($module: ident, $name: ident, $base: ty) => {
         pub struct $name($crate::PyObject);
@@ -105,7 +105,7 @@ macro_rules! py_exception {
                     if type_object.is_null() {
                         type_object = $crate::PyErr::new_type(
                             py,
-                            concat!(stringify!($module), ".", stringify!($name)),
+                            _cpython__err__concat!(_cpython__err__stringify!($module), ".", _cpython__err__stringify!($name)),
                             Some($crate::PythonObject::into_object(py.get_type::<$base>())),
                             None).as_type_ptr();
                     }
@@ -447,6 +447,25 @@ pub fn error_on_minusone(py : Python, result : libc::c_int) -> PyResult<()> {
         Ok(())
     } else {
         Err(PyErr::fetch(py))
+    }
+}
+
+
+// 2018 macros support
+//
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__err__concat {
+    ($($inner:tt)*) => {
+        concat! { $($inner)* }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__err__stringify {
+    ($($inner:tt)*) => {
+        stringify! { $($inner)* }
     }
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -97,7 +97,7 @@ macro_rules! py_method_def {
 ///     py.run("print(multiply(6, 7))", None, Some(&dict)).unwrap();
 /// }
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! py_fn {
     ($py:expr, $f:ident $plist:tt ) => {
         py_argparse_parse_plist! { py_fn_impl { $py, $f } $plist }
@@ -107,7 +107,7 @@ macro_rules! py_fn {
     };
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_fn_impl {
     // Form 1: reference existing function
@@ -119,9 +119,9 @@ macro_rules! py_fn_impl {
         -> *mut $crate::_detail::ffi::PyObject
         {
             $crate::_detail::handle_callback(
-                stringify!($f), $crate::_detail::PyObjectCallbackConverter,
+                _cpython__function__stringify!($f), $crate::_detail::PyObjectCallbackConverter,
                 |py| {
-                    py_argparse_raw!(py, Some(stringify!($f)), args, kwargs,
+                    py_argparse_raw!(py, Some(_cpython__function__stringify!($f)), args, kwargs,
                         [ $( { $pname : $ptype = $detail } )* ]
                         {
                             $f(py $(, $pname )* )
@@ -130,7 +130,7 @@ macro_rules! py_fn_impl {
         }
         unsafe {
             $crate::_detail::py_fn_impl($py,
-                py_method_def!(stringify!($f), 0, wrap))
+                py_method_def!(_cpython__function__stringify!($f), 0, wrap))
         }
     }};
     // Form 2: inline function definition
@@ -232,5 +232,13 @@ impl <'a> Drop for AbortOnDrop<'a> {
     }
 }
 
-// Tests for this file are in tests/test_function.rs
+// Rust 2018 support
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _cpython__function__stringify {
+    ($($inner:tt)*) => {
+        stringify! { $($inner)* }
+    }
+}
 
+// Tests for this file are in tests/test_function.rs

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -38,7 +38,7 @@ pub use self::num::PyLong as PyInt;
 pub use self::num::{PyLong, PyFloat};
 pub use self::sequence::PySequence;
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! pyobject_newtype(
     ($name: ident) => (
         py_impl_to_py_object_for_python_object!($name);

--- a/src/py_class/members.rs
+++ b/src/py_class/members.rs
@@ -64,7 +64,7 @@ macro_rules! py_class_init_members {
     }};
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_class_instance_method {
     ($py:ident, $class:ident :: $f:ident [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]) => {{
@@ -74,7 +74,7 @@ macro_rules! py_class_instance_method {
             kwargs: *mut $crate::_detail::ffi::PyObject)
         -> *mut $crate::_detail::ffi::PyObject
         {
-            const LOCATION: &'static str = concat!(stringify!($class), ".", stringify!($f), "()");
+            const LOCATION: &'static str = _cpython__py_class__members__concat!(_cpython__py_class__members__stringify!($class), ".", _cpython__py_class__members__stringify!($f), "()");
             $crate::_detail::handle_callback(
                 LOCATION, $crate::_detail::PyObjectCallbackConverter,
                 |py| {
@@ -89,7 +89,7 @@ macro_rules! py_class_instance_method {
                 })
         }
         unsafe {
-            let method_def = py_method_def!(stringify!($f), 0, wrap_instance_method);
+            let method_def = py_method_def!(_cpython__py_class__members__stringify!($f), 0, wrap_instance_method);
             $crate::py_class::members::create_instance_method_descriptor::<$class>(method_def)
         }
     }}
@@ -121,7 +121,7 @@ macro_rules! py_class_class_method {
             kwargs: *mut $crate::_detail::ffi::PyObject)
         -> *mut $crate::_detail::ffi::PyObject
         {
-            const LOCATION: &'static str = concat!(stringify!($class), ".", stringify!($f), "()");
+            const LOCATION: &'static str = _cpython__py_class__members__concat!(_cpython__py_class__members__stringify!($class), ".", _cpython__py_class__members__stringify!($f), "()");
             $crate::_detail::handle_callback(
                 LOCATION, $crate::_detail::PyObjectCallbackConverter,
                 |py| {
@@ -136,7 +136,7 @@ macro_rules! py_class_class_method {
                 })
         }
         unsafe {
-            let method_def = py_method_def!(stringify!($f),
+            let method_def = py_method_def!(_cpython__py_class__members__stringify!($f),
                 $crate::_detail::ffi::METH_CLASS,
                 wrap_class_method);
             $crate::py_class::members::create_class_method_descriptor(method_def)
@@ -171,7 +171,7 @@ macro_rules! py_class_static_method {
             kwargs: *mut $crate::_detail::ffi::PyObject)
         -> *mut $crate::_detail::ffi::PyObject
         {
-            const LOCATION: &'static str = concat!(stringify!($class), ".", stringify!($f), "()");
+            const LOCATION: &'static str = _cpython__py_class__members__concat!(_cpython__py_class__members__stringify!($class), ".", _cpython__py_class__members__stringify!($f), "()");
             $crate::_detail::handle_callback(
                 LOCATION, $crate::_detail::PyObjectCallbackConverter,
                 |py| {
@@ -183,7 +183,7 @@ macro_rules! py_class_static_method {
                 })
         }
         unsafe {
-            let method_def = py_method_def!(stringify!($f),
+            let method_def = py_method_def!(_cpython__py_class__members__stringify!($f),
                 $crate::_detail::ffi::METH_STATIC,
                 wrap_static_method);
             $crate::_detail::py_fn_impl($py, method_def)
@@ -191,4 +191,19 @@ macro_rules! py_class_static_method {
     }}
 }
 
+// Rust 2018 support
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _cpython__py_class__members__stringify {
+    ($($inner:tt)*) => {
+        stringify! { $($inner)* }
+    }
+}
 
+#[macro_export]
+#[doc(hidden)]
+macro_rules! _cpython__py_class__members__concat {
+    ($($inner:tt)*) => {
+        concat! { $($inner)* }
+    }
+}

--- a/src/py_class/py_class_impl.py
+++ b/src/py_class/py_class_impl.py
@@ -30,7 +30,7 @@ header = '''
 '''
 
 macro_start = '''
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_class_impl {
     // TT muncher macro. Results are accumulated in $info $slots $impls and $members.
@@ -153,7 +153,7 @@ base_case = '''
                                 } else {
                                     // automatically initialize the class on-demand
                                     <$class as $crate::py_class::PythonObjectFromPyClassMacro>::initialize(py, None)
-                                        .expect(concat!("An error occurred while initializing class ", stringify!($class)))
+                                        .expect(_cpython__py_class__py_class_impl__concat!("An error occurred while initializing class ", _cpython__py_class__py_class_impl__stringify!($class)))
                                 }
                             }
                         }
@@ -165,9 +165,9 @@ base_case = '''
                                 if $crate::py_class::is_ready(py, &TYPE_OBJECT) {
                                     return Ok($crate::PyType::from_type_ptr(py, &mut TYPE_OBJECT));
                                 }
-                                assert!(!INIT_ACTIVE,
-                                    concat!("Reentrancy detected: already initializing class ",
-                                    stringify!($class)));
+                                _cpython__py_class__py_class_impl__assert!(!INIT_ACTIVE,
+                                    _cpython__py_class__py_class_impl__concat!("Reentrancy detected: already initializing class ",
+                                    _cpython__py_class__py_class_impl__stringify!($class)));
                                 INIT_ACTIVE = true;
                                 let res = init(py, module_name);
                                 INIT_ACTIVE = false;
@@ -177,7 +177,7 @@ base_case = '''
 
                         fn add_to_module(py: $crate::Python, module: &$crate::PyModule) -> $crate::PyResult<()> {
                             let ty = <$class as $crate::py_class::PythonObjectFromPyClassMacro>::initialize(py, module.name(py).ok())?;
-                            module.add(py, stringify!($class), ty)
+                            module.add(py, _cpython__py_class__py_class_impl__stringify!($class), ty)
                         }
                     }
 
@@ -489,6 +489,30 @@ def static_data():
         new_members=[('$name', '$init')])
 
 macro_end = '''
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__py_class__py_class_impl__concat {
+    ($($inner:tt)*) => {
+        concat! { $($inner)* }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__py_class__py_class_impl__stringify {
+    ($($inner:tt)*) => {
+        stringify! { $($inner)* }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__py_class__py_class_impl__assert {
+    ($($inner:tt)*) => {
+        assert! { $($inner)* }
+    }
 }
 '''
 

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -23,7 +23,7 @@
 //       DO NOT MODIFY      !!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_class_impl {
     // TT muncher macro. Results are accumulated in $info $slots $impls and $members.
@@ -145,7 +145,7 @@ macro_rules! py_class_impl {
                                 } else {
                                     // automatically initialize the class on-demand
                                     <$class as $crate::py_class::PythonObjectFromPyClassMacro>::initialize(py, None)
-                                        .expect(concat!("An error occurred while initializing class ", stringify!($class)))
+                                        .expect(_cpython__py_class__py_class_impl__concat!("An error occurred while initializing class ", _cpython__py_class__py_class_impl__stringify!($class)))
                                 }
                             }
                         }
@@ -157,9 +157,9 @@ macro_rules! py_class_impl {
                                 if $crate::py_class::is_ready(py, &TYPE_OBJECT) {
                                     return Ok($crate::PyType::from_type_ptr(py, &mut TYPE_OBJECT));
                                 }
-                                assert!(!INIT_ACTIVE,
-                                    concat!("Reentrancy detected: already initializing class ",
-                                    stringify!($class)));
+                                _cpython__py_class__py_class_impl__assert!(!INIT_ACTIVE,
+                                    _cpython__py_class__py_class_impl__concat!("Reentrancy detected: already initializing class ",
+                                    _cpython__py_class__py_class_impl__stringify!($class)));
                                 INIT_ACTIVE = true;
                                 let res = init(py, module_name);
                                 INIT_ACTIVE = false;
@@ -169,7 +169,7 @@ macro_rules! py_class_impl {
 
                         fn add_to_module(py: $crate::Python, module: &$crate::PyModule) -> $crate::PyResult<()> {
                             let ty = <$class as $crate::py_class::PythonObjectFromPyClassMacro>::initialize(py, module.name(py).ok())?;
-                            module.add(py, stringify!($class), ty)
+                            module.add(py, _cpython__py_class__py_class_impl__stringify!($class), ty)
                         }
                     }
 
@@ -1794,7 +1794,7 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name = 
+            $name =
             py_argparse_parse_plist!{
                 py_class_static_method {$py, $class::$name}
                 ($($p)*)
@@ -1814,5 +1814,29 @@ macro_rules! py_class_impl {
         }
     }};
 
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__py_class__py_class_impl__concat {
+    ($($inner:tt)*) => {
+        concat! { $($inner)* }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__py_class__py_class_impl__stringify {
+    ($($inner:tt)*) => {
+        stringify! { $($inner)* }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__py_class__py_class_impl__assert {
+    ($($inner:tt)*) => {
+        assert! { $($inner)* }
+    }
 }
 

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -23,7 +23,7 @@
 //       DO NOT MODIFY      !!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_class_impl {
     // TT muncher macro. Results are accumulated in $info $slots $impls and $members.
@@ -145,7 +145,7 @@ macro_rules! py_class_impl {
                                 } else {
                                     // automatically initialize the class on-demand
                                     <$class as $crate::py_class::PythonObjectFromPyClassMacro>::initialize(py, None)
-                                        .expect(concat!("An error occurred while initializing class ", stringify!($class)))
+                                        .expect(_cpython__py_class__py_class_impl__concat!("An error occurred while initializing class ", _cpython__py_class__py_class_impl__stringify!($class)))
                                 }
                             }
                         }
@@ -157,9 +157,9 @@ macro_rules! py_class_impl {
                                 if $crate::py_class::is_ready(py, &TYPE_OBJECT) {
                                     return Ok($crate::PyType::from_type_ptr(py, &mut TYPE_OBJECT));
                                 }
-                                assert!(!INIT_ACTIVE,
-                                    concat!("Reentrancy detected: already initializing class ",
-                                    stringify!($class)));
+                                _cpython__py_class__py_class_impl__assert!(!INIT_ACTIVE,
+                                    _cpython__py_class__py_class_impl__concat!("Reentrancy detected: already initializing class ",
+                                    _cpython__py_class__py_class_impl__stringify!($class)));
                                 INIT_ACTIVE = true;
                                 let res = init(py, module_name);
                                 INIT_ACTIVE = false;
@@ -169,7 +169,7 @@ macro_rules! py_class_impl {
 
                         fn add_to_module(py: $crate::Python, module: &$crate::PyModule) -> $crate::PyResult<()> {
                             let ty = <$class as $crate::py_class::PythonObjectFromPyClassMacro>::initialize(py, module.name(py).ok())?;
-                            module.add(py, stringify!($class), ty)
+                            module.add(py, _cpython__py_class__py_class_impl__stringify!($class), ty)
                         }
                     }
 
@@ -1794,7 +1794,7 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name = 
+            $name =
             py_argparse_parse_plist!{
                 py_class_static_method {$py, $class::$name}
                 ($($p)*)
@@ -1814,5 +1814,29 @@ macro_rules! py_class_impl {
         }
     }};
 
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__py_class__py_class_impl__concat {
+    ($($inner:tt)*) => {
+        concat! { $($inner)* }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__py_class__py_class_impl__stringify {
+    ($($inner:tt)*) => {
+        stringify! { $($inner)* }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__py_class__py_class_impl__assert {
+    ($($inner:tt)*) => {
+        assert! { $($inner)* }
+    }
 }
 

--- a/src/py_class/slots.rs
+++ b/src/py_class/slots.rs
@@ -29,7 +29,7 @@ use py_class::{CompareOp};
 use exc;
 use Py_hash_t;
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_class_type_object_static_init {
     ($class_name:ident,
@@ -77,7 +77,7 @@ pub const TPFLAGS_DEFAULT : ::libc::c_long = ffi::Py_TPFLAGS_DEFAULT
 #[cfg(feature="python3-sys")]
 pub const TPFLAGS_DEFAULT : ::libc::c_ulong = ffi::Py_TPFLAGS_DEFAULT;
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_class_type_object_dynamic_init {
     // initialize those fields of PyTypeObject that we couldn't initialize statically
@@ -92,7 +92,7 @@ macro_rules! py_class_type_object_dynamic_init {
     ) => {
         unsafe {
             $type_object.init_ob_type(&mut $crate::_detail::ffi::PyType_Type);
-            $type_object.tp_name = $crate::py_class::slots::build_tp_name($module_name, stringify!($class));
+            $type_object.tp_name = $crate::py_class::slots::build_tp_name($module_name, _cpython__py_class__slots__stringify!($class));
             $type_object.tp_basicsize = <$class as $crate::py_class::BaseObject>::size()
                                         as $crate::_detail::ffi::Py_ssize_t;
         }
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn tp_dealloc_callback<T>(obj: *mut ffi::PyObject)
     r
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_class_wrap_newfunc {
     ($class:ident :: $f:ident [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]) => {{
@@ -131,7 +131,7 @@ macro_rules! py_class_wrap_newfunc {
             kwargs: *mut $crate::_detail::ffi::PyObject)
         -> *mut $crate::_detail::ffi::PyObject
         {
-            const LOCATION: &'static str = concat!(stringify!($class), ".", stringify!($f), "()");
+            const LOCATION: &'static str = _cpython__py_class__slots__concat!(_cpython__py_class__slots__stringify!($class), ".", _cpython__py_class__slots__stringify!($f), "()");
             $crate::_detail::handle_callback(
                 LOCATION, $crate::_detail::PyObjectCallbackConverter,
                 |py| {
@@ -180,7 +180,7 @@ macro_rules! py_class_as_number {
     }}
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_class_as_mapping {
     ( $type_object:ident, [], [
@@ -565,7 +565,7 @@ impl CallbackConverter<bool> for BoolConverter {
 }
 
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! py_class_call_slot {
     ($class:ident :: $f:ident [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]) => {{
@@ -575,7 +575,7 @@ macro_rules! py_class_call_slot {
             kwargs: *mut $crate::_detail::ffi::PyObject)
         -> *mut $crate::_detail::ffi::PyObject
         {
-            const LOCATION: &'static str = concat!(stringify!($class), ".", stringify!($f), "()");
+            const LOCATION: &'static str = _cpython__py_class__slots__concat!(_cpython__py_class__slots__stringify!($class), ".", _cpython__py_class__slots__stringify!($f), "()");
             $crate::_detail::handle_callback(
                 LOCATION, $crate::_detail::PyObjectCallbackConverter,
                 |py| {
@@ -604,3 +604,18 @@ pub unsafe extern "C" fn sq_item(obj: *mut ffi::PyObject, index: ffi::Py_ssize_t
     ret
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__py_class__slots__concat {
+    ($($inner:tt)*) => {
+        concat! { $($inner)* }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__py_class__slots__stringify {
+    ($($inner:tt)*) => {
+        stringify! { $($inner)* }
+    }
+}


### PR DESCRIPTION
I've updated the macros to work with rust 2018, following the [edition guide](https://rust-lang-nursery.github.io/edition-guide/rust-2018/macros/macro-changes.html).