### PR TITLE
High level Capsule support

### DIFF
--- a/src/objects/capsule.rs
+++ b/src/objects/capsule.rs
@@ -399,7 +399,7 @@ macro_rules! py_capsule {
 ///     pymod.add(py, "capsfn", caps).unwrap();
 ///  }
 ///
-/// py_capsule_fn!(from sys import capsfn as capsmod: fn(a: c_int) -> c_int);
+/// py_capsule_fn!(from sys import capsfn as capsmod signature (a: c_int) -> c_int);
 ///
 /// // One could, e.g., reexport if needed:
 /// pub use capsmod::CapsuleFn;
@@ -424,7 +424,7 @@ macro_rules! py_capsule {
 /// [`PyCapsule`]: struct.PyCapsule.html
 #[macro_export]
 macro_rules! py_capsule_fn {
-    (from $($capsmod:ident).+ import $capsname:ident as $rustmod:ident : fn$( $sig: tt)* ) => (
+    (from $($capsmod:ident).+ import $capsname:ident as $rustmod:ident signature $( $sig: tt)* ) => (
         mod $rustmod {
             use super::*;
             use std::sync::Once;

--- a/src/objects/capsule.rs
+++ b/src/objects/capsule.rs
@@ -187,7 +187,6 @@ pub struct PyCapsule(PyObject);
 
 pyobject_newtype!(PyCapsule, PyCapsule_CheckExact, PyCapsule_Type);
 
-
 /// Macro to retrieve a Python capsule pointing to an array of data, with a layer of caching.
 ///
 /// For more details on capsules, see [`PyCapsule`]
@@ -491,11 +490,10 @@ impl PyCapsule {
     ///
     /// May panic when running out of memory.
     ///
-    pub fn new_data<T>(
-        py: Python,
-        data: &mut T,
-        name: impl Into<Vec<u8>>,
-    ) -> Result<Self, NulError> {
+    pub fn new_data<T, N>(py: Python, data: &mut T, name: N) -> Result<Self, NulError>
+    where
+        N: Into<Vec<u8>>,
+    {
         Self::new(py, data as *mut T as *mut c_void, name)
     }
 
@@ -516,11 +514,10 @@ impl PyCapsule {
     ///
     /// # Errors
     /// This method returns `NulError` if `name` contains a 0 byte (see also `CString::new`)
-    pub fn new(
-        py: Python,
-        pointer: *mut c_void,
-        name: impl Into<Vec<u8>>,
-    ) -> Result<Self, NulError> {
+    pub fn new<N>(py: Python, pointer: *mut c_void, name: N) -> Result<Self, NulError>
+    where
+        N: Into<Vec<u8>>,
+    {
         let name = CString::new(name)?;
         let caps = unsafe {
             Ok(err::cast_from_owned_ptr_or_panic(
@@ -548,7 +545,10 @@ impl PyCapsule {
     ///
     /// # Errors
     /// This method returns `NulError` if `name` contains a 0 byte (see also `CString::new`)
-    pub unsafe fn data_ref<'a, T>(&self, name: impl Into<Vec<u8>>) -> Result<&'a T, NulError> {
+    pub unsafe fn data_ref<'a, T, N>(&self, name: N) -> Result<&'a T, NulError>
+    where
+        N: Into<Vec<u8>>,
+    {
         Ok(self.data_ref_cstr(&CString::new(name)?))
     }
 

--- a/src/objects/capsule.rs
+++ b/src/objects/capsule.rs
@@ -8,7 +8,181 @@ use python::{Python, ToPythonPointer};
 use std::ffi::{CStr, CString, NulError};
 use std::mem;
 
-/// Represents a Python capsule object.
+/// Capsules are the preferred way to export/import C APIs between extension modules,
+/// see [Providing a C API for an Extension Module](https://docs.python.org/3/extending/extending.html#using-capsules).
+///
+/// In particular, capsules can be very useful to start adding Rust extensions besides
+/// existing traditional C ones, be it for gradual rewrites or to extend with new functionality.
+/// They can also be used for interaction between independently compiled Rust extensions if needed.
+///
+/// Capsules can point to data, usually static arrays of constants and function pointers,
+/// or to function pointers directly. These two cases have to be handled differently in Rust,
+/// and the latter is possible only for architectures were data and function pointers have
+/// the same sizes.
+///
+/// # Examples
+/// ## Using a capsule defined in another extension module
+/// This retrieves and use one of the simplest capsules in the Python standard library, found in
+/// the `unicodedata` module. The C API enclosed in this capsule is the same for all Python
+/// versions supported by this crate. This is not the case of all capsules from the standard
+/// library. For instance the `struct` referenced by `datetime.datetime_CAPI` gets a new member
+/// in version 3.7.
+///
+/// Note: this example is a lower-level version of the [`py_capsule!`] example. Only the
+/// capsule retrieval actually differs.
+/// ```
+/// #[macro_use] extern crate cpython;
+/// extern crate libc;
+///
+/// use cpython::{Python, PyCapsule};
+/// use libc::{c_char, c_int};
+/// use std::ffi::{c_void, CStr, CString};
+/// use std::mem;
+/// use std::ptr::null_mut;
+///
+/// #[allow(non_camel_case_types)]
+/// type Py_UCS4 = u32;
+/// const UNICODE_NAME_MAXLEN: usize = 256;
+///
+/// #[repr(C)]
+/// pub struct unicode_name_CAPI {
+///     // the `ucd` signature arguments are actually optional (can be `NULL`) FFI PyObject
+///     // pointers used to pass alternate (former) versions of Unicode data.
+///     // We won't need to use them with an actual value in these examples, so it's enough to
+///     // specify them as `*mut c_void`, and it spares us a direct reference to the lower
+///     // level Python FFI bindings.
+///     size: c_int,
+///     getname: unsafe extern "C" fn(
+///         ucd: *mut c_void,
+///         code: Py_UCS4,
+///         buffer: *mut c_char,
+///         buflen: c_int,
+///         with_alias_and_seq: c_int,
+///     ) -> c_int,
+///     getcode: unsafe extern "C" fn(
+///         ucd: *mut c_void,
+///         name: *const c_char,
+///         namelen: c_int,
+///         code: *mut Py_UCS4,
+///     ) -> c_int,
+/// }
+///
+/// #[derive(Debug, PartialEq)]
+/// pub enum UnicodeDataError {
+///     InvalidCode,
+///     UnknownName,
+/// }
+///
+/// impl unicode_name_CAPI {
+///     pub fn get_name(&self, code: Py_UCS4) -> Result<CString, UnicodeDataError> {
+///         let mut buf: Vec<c_char> = Vec::with_capacity(UNICODE_NAME_MAXLEN);
+///         let buf_ptr = buf.as_mut_ptr();
+///         if unsafe {
+///           ((*self).getname)(null_mut(), code, buf_ptr, UNICODE_NAME_MAXLEN as c_int, 0)
+///         } != 1 {
+///             return Err(UnicodeDataError::InvalidCode);
+///         }
+///         mem::forget(buf);
+///         Ok(unsafe { CString::from_raw(buf_ptr) })
+///     }
+///
+///     pub fn get_code(&self, name: &CStr) -> Result<Py_UCS4, UnicodeDataError> {
+///         let namelen = name.to_bytes().len() as c_int;
+///         let mut code: [Py_UCS4; 1] = [0; 1];
+///         if unsafe {
+///             ((*self).getcode)(null_mut(), name.as_ptr(), namelen, code.as_mut_ptr())
+///         } != 1 {
+///             return Err(UnicodeDataError::UnknownName);
+///         }
+///         Ok(code[0])
+///     }
+/// }
+///
+/// let gil = Python::acquire_gil();
+/// let py = gil.python();
+///
+/// let capi: &unicode_name_CAPI = unsafe {
+///     PyCapsule::import_data(
+///         py,
+///         CStr::from_bytes_with_nul_unchecked(b"unicodedata.ucnhash_CAPI\0"),
+///     )
+/// }
+/// .unwrap();
+///
+/// assert_eq!(capi.get_name(32).unwrap().to_str(), Ok("SPACE"));
+/// assert_eq!(capi.get_name(0), Err(UnicodeDataError::InvalidCode));
+///
+/// assert_eq!(
+///     capi.get_code(CStr::from_bytes_with_nul(b"COMMA\0").unwrap()),
+///     Ok(44)
+/// );
+/// assert_eq!(
+///     capi.get_code(CStr::from_bytes_with_nul(b"\0").unwrap()),
+///     Err(UnicodeDataError::UnknownName)
+/// );
+/// ```
+///
+/// ## Creating a capsule from Rust
+/// In this example, we enclose some data and a function in a capsule, using an intermediate
+/// `struct` as enclosing type, then retrieve them back and use them.
+///
+/// ```
+/// extern crate cpython;
+/// extern crate libc;
+///
+/// use libc::c_int;
+/// use cpython::{PyCapsule, Python};
+/// use std::ffi::{c_void, CStr, CString};
+///
+/// #[repr(C)]
+/// struct CapsData {
+///     value: c_int,
+///     fun: fn(c_int, c_int) -> c_int,
+/// }
+///
+/// fn add(a: c_int, b: c_int) -> c_int {
+///     a + b
+/// }
+///
+/// const DATA: CapsData = CapsData{value: 1, fun: add};
+///
+/// let gil = Python::acquire_gil();
+/// let py = gil.python();
+/// let caps = PyCapsule::new_data(py, &mut DATA, "somemod.capsdata").unwrap();
+///
+/// let retrieved: &CapsData = unsafe {caps.data_ref("somemod.capsdata")}.unwrap();
+/// assert_eq!(retrieved.value, 1);
+/// assert_eq!((retrieved.fun)(2 as c_int, 3 as c_int), 5);
+/// ```
+///
+/// Of course, a more realistic example would be to store the capsule in a Python module,
+/// allowing another extension (possibly foreign) to retrieve and use it.
+/// Note that in that case, the capsule `name` must be full dotted name of the capsule object,
+/// as we're doing here.
+/// ```
+/// # #[macro_use] extern crate cpython;
+/// # extern crate libc;
+/// # use libc::c_int;
+/// # use cpython::PyCapsule;
+/// # #[repr(C)]
+/// # struct CapsData {
+/// #     value: c_int,
+/// #     fun: fn(c_int, c_int) -> c_int,
+/// # }
+/// # fn add(a: c_int, b: c_int) -> c_int {
+/// #     a + b
+/// # }
+/// # const DATA: CapsData = CapsData{value: 1, fun: add};
+/// py_module_initializer!(somemod, initsomemod, PyInit_somemod, |py, m| {
+///   m.add(py, "__doc__", "A module holding a capsule")?;
+///   m.add(py, "capsdata", PyCapsule::new_data(py, &mut DATA, "somemod.capsdata").unwrap())?;
+///   Ok(())
+/// });
+/// ```
+/// Another Rust extension could then declare `CapsData` and use `PyCapsule::import_data` to
+/// fetch it back.
+///
+/// [`py_capsule!`]: macro.py_capsule.html
 pub struct PyCapsule(PyObject);
 
 pyobject_newtype!(PyCapsule, PyCapsule_CheckExact, PyCapsule_Type);
@@ -267,181 +441,6 @@ macro_rules! py_capsule_fn {
     )
 }
 
-/// Capsules are the preferred way to export/import C APIs between extension modules,
-/// see [Providing a C API for an Extension Module](https://docs.python.org/3/extending/extending.html#using-capsules).
-///
-/// In particular, capsules can be very useful to start adding Rust extensions besides
-/// existing traditional C ones, be it for gradual rewrites or to extend with new functionality.
-/// They can also be used for interaction between independently compiled Rust extensions if needed.
-///
-/// Capsules can point to data, usually static arrays of constants and function pointers,
-/// or to function pointers directly. These two cases have to be handled differently in Rust,
-/// and the latter is possible only for architectures were data and function pointers have
-/// the same sizes.
-///
-/// # Examples
-/// ## Using a capsule defined in another extension module
-/// This retrieves and use one of the simplest capsules in the Python standard library, found in
-/// the `unicodedata` module. The C API enclosed in this capsule is the same for all Python
-/// versions supported by this crate. This is not the case of all capsules from the standard
-/// library. For instance the `struct` referenced by `datetime.datetime_CAPI` gets a new member
-/// in version 3.7.
-///
-/// Note: this example is a lower-level version of the [`py_capsule!`] example. Only the
-/// capsule retrieval actually differs.
-/// ```
-/// #[macro_use] extern crate cpython;
-/// extern crate libc;
-///
-/// use cpython::{Python, PyCapsule};
-/// use libc::{c_char, c_int};
-/// use std::ffi::{c_void, CStr, CString};
-/// use std::mem;
-/// use std::ptr::null_mut;
-///
-/// #[allow(non_camel_case_types)]
-/// type Py_UCS4 = u32;
-/// const UNICODE_NAME_MAXLEN: usize = 256;
-///
-/// #[repr(C)]
-/// pub struct unicode_name_CAPI {
-///     // the `ucd` signature arguments are actually optional (can be `NULL`) FFI PyObject
-///     // pointers used to pass alternate (former) versions of Unicode data.
-///     // We won't need to use them with an actual value in these examples, so it's enough to
-///     // specify them as `*mut c_void`, and it spares us a direct reference to the lower
-///     // level Python FFI bindings.
-///     size: c_int,
-///     getname: unsafe extern "C" fn(
-///         ucd: *mut c_void,
-///         code: Py_UCS4,
-///         buffer: *mut c_char,
-///         buflen: c_int,
-///         with_alias_and_seq: c_int,
-///     ) -> c_int,
-///     getcode: unsafe extern "C" fn(
-///         ucd: *mut c_void,
-///         name: *const c_char,
-///         namelen: c_int,
-///         code: *mut Py_UCS4,
-///     ) -> c_int,
-/// }
-///
-/// #[derive(Debug, PartialEq)]
-/// pub enum UnicodeDataError {
-///     InvalidCode,
-///     UnknownName,
-/// }
-///
-/// impl unicode_name_CAPI {
-///     pub fn get_name(&self, code: Py_UCS4) -> Result<CString, UnicodeDataError> {
-///         let mut buf: Vec<c_char> = Vec::with_capacity(UNICODE_NAME_MAXLEN);
-///         let buf_ptr = buf.as_mut_ptr();
-///         if unsafe {
-///           ((*self).getname)(null_mut(), code, buf_ptr, UNICODE_NAME_MAXLEN as c_int, 0)
-///         } != 1 {
-///             return Err(UnicodeDataError::InvalidCode);
-///         }
-///         mem::forget(buf);
-///         Ok(unsafe { CString::from_raw(buf_ptr) })
-///     }
-///
-///     pub fn get_code(&self, name: &CStr) -> Result<Py_UCS4, UnicodeDataError> {
-///         let namelen = name.to_bytes().len() as c_int;
-///         let mut code: [Py_UCS4; 1] = [0; 1];
-///         if unsafe {
-///             ((*self).getcode)(null_mut(), name.as_ptr(), namelen, code.as_mut_ptr())
-///         } != 1 {
-///             return Err(UnicodeDataError::UnknownName);
-///         }
-///         Ok(code[0])
-///     }
-/// }
-///
-/// let gil = Python::acquire_gil();
-/// let py = gil.python();
-///
-/// let capi: &unicode_name_CAPI = unsafe {
-///     PyCapsule::import_data(
-///         py,
-///         CStr::from_bytes_with_nul_unchecked(b"unicodedata.ucnhash_CAPI\0"),
-///     )
-/// }
-/// .unwrap();
-///
-/// assert_eq!(capi.get_name(32).unwrap().to_str(), Ok("SPACE"));
-/// assert_eq!(capi.get_name(0), Err(UnicodeDataError::InvalidCode));
-///
-/// assert_eq!(
-///     capi.get_code(CStr::from_bytes_with_nul(b"COMMA\0").unwrap()),
-///     Ok(44)
-/// );
-/// assert_eq!(
-///     capi.get_code(CStr::from_bytes_with_nul(b"\0").unwrap()),
-///     Err(UnicodeDataError::UnknownName)
-/// );
-/// ```
-///
-/// ## Creating a capsule from Rust
-/// In this example, we enclose some data and a function in a capsule, using an intermediate
-/// `struct` as enclosing type, then retrieve them back and use them.
-///
-/// ```
-/// extern crate cpython;
-/// extern crate libc;
-///
-/// use libc::c_int;
-/// use cpython::{PyCapsule, Python};
-/// use std::ffi::{c_void, CStr, CString};
-///
-/// #[repr(C)]
-/// struct CapsData {
-///     value: c_int,
-///     fun: fn(c_int, c_int) -> c_int,
-/// }
-///
-/// fn add(a: c_int, b: c_int) -> c_int {
-///     a + b
-/// }
-///
-/// const DATA: CapsData = CapsData{value: 1, fun: add};
-///
-/// let gil = Python::acquire_gil();
-/// let py = gil.python();
-/// let caps = PyCapsule::new_data(py, &mut DATA, "somemod.capsdata").unwrap();
-///
-/// let retrieved: &CapsData = unsafe {caps.data_ref("somemod.capsdata")}.unwrap();
-/// assert_eq!(retrieved.value, 1);
-/// assert_eq!((retrieved.fun)(2 as c_int, 3 as c_int), 5);
-/// ```
-///
-/// Of course, a more realistic example would be to store the capsule in a Python module,
-/// allowing another extension (possibly foreign) to retrieve and use it.
-/// Note that in that case, the capsule `name` must be full dotted name of the capsule object,
-/// as we're doing here.
-/// ```
-/// # #[macro_use] extern crate cpython;
-/// # extern crate libc;
-/// # use libc::c_int;
-/// # use cpython::PyCapsule;
-/// # #[repr(C)]
-/// # struct CapsData {
-/// #     value: c_int,
-/// #     fun: fn(c_int, c_int) -> c_int,
-/// # }
-/// # fn add(a: c_int, b: c_int) -> c_int {
-/// #     a + b
-/// # }
-/// # const DATA: CapsData = CapsData{value: 1, fun: add};
-/// py_module_initializer!(somemod, initsomemod, PyInit_somemod, |py, m| {
-///   m.add(py, "__doc__", "A module holding a capsule")?;
-///   m.add(py, "capsdata", PyCapsule::new_data(py, &mut DATA, "somemod.capsdata").unwrap())?;
-///   Ok(())
-/// });
-/// ```
-/// Another Rust extension could then declare `CapsData` and use `PyCapsule::import_data` to
-/// fetch it back.
-///
-/// [`py_capsule!`]: macro.py_capsule.html
 impl PyCapsule {
     /// Retrieve the contents of a capsule pointing to some data as a reference.
     ///

--- a/src/objects/capsule.rs
+++ b/src/objects/capsule.rs
@@ -160,9 +160,11 @@ macro_rules! py_capsule {
     )
 }
 
-/// Macro to retrieve a function pointer capsule
+/// Macro to retrieve a function pointer capsule.
 ///
-/// For general explanations about Capsules, see [`PyCapsule`].
+/// This is not suitable for architectures where the sizes of function and data pointers
+/// differ.
+/// For general explanations about capsules, see [`PyCapsule`].
 ///
 /// This macro takes the following arguments:
 /// - segments of the full Python dotted name of the capsule
@@ -460,7 +462,9 @@ impl PyCapsule {
     ///
     /// This is suitable in particular for later conversion as a function pointer
     /// with `mem::transmute`, for architectures where data and function pointers have
-    /// the same size (see details about this the documentation of the Rust standard library).
+    /// the same size (see details about this in the
+    /// [documentation](https://doc.rust-lang.org/std/mem/fn.transmute.html#examples)
+    /// of the Rust standard library).
     pub fn import(py: Python, name: &CStr) -> PyResult<*mut c_void> {
         let caps_ptr = unsafe { PyCapsule_Import(name.as_ptr(), 0) };
         if caps_ptr.is_null() {

--- a/src/objects/capsule.rs
+++ b/src/objects/capsule.rs
@@ -349,8 +349,8 @@ macro_rules! py_capsule {
 ///
 /// ```ignore
 /// mod $rustmod {
-///     pub type CapsFn = unsafe extern "C" ( ... ) -> ... ;
-///     pub unsafe fn retrieve<'a>(py: Python) -> PyResult<CapsFn) { ... }
+///     pub type CapsuleFn = unsafe extern "C" ( ... ) -> ... ;
+///     pub unsafe fn retrieve<'a>(py: Python) -> PyResult<CapsuleFn) { ... }
 /// }
 /// ```
 ///
@@ -384,7 +384,7 @@ macro_rules! py_capsule {
 /// py_capsule_fn!(sys, capsfn, capsmod, (a: c_int) -> c_int);
 ///
 /// // One could, e.g., reexport if needed:
-/// pub use capsmod::CapsFn;
+/// pub use capsmod::CapsuleFn;
 ///
 /// fn retrieve_use_capsule() {
 ///     let gil = Python::acquire_gil();
@@ -393,7 +393,7 @@ macro_rules! py_capsule {
 ///     assert_eq!( unsafe { fun(1) }, 2);
 ///
 ///     // let's demonstrate the (reexported) function type
-///     let g: CapsFn = fun;
+///     let g: CapsuleFn = fun;
 /// }
 ///
 /// fn main() {
@@ -411,13 +411,13 @@ macro_rules! py_capsule_fn {
             use std::sync::Once;
             use $crate::PyClone;
 
-            pub type CapsFn = unsafe extern "C" fn $( $sig )*;
+            pub type CapsuleFn = unsafe extern "C" fn $( $sig )*;
 
-            static mut CAPS_FN: Option<$crate::PyResult<CapsFn>> = None;
+            static mut CAPS_FN: Option<$crate::PyResult<CapsuleFn>> = None;
 
             static INIT: Once = Once::new();
 
-            fn import(py: $crate::Python) -> $crate::PyResult<CapsFn> {
+            fn import(py: $crate::Python) -> $crate::PyResult<CapsuleFn> {
                 unsafe {
                     let caps_name =
                         std::ffi::CStr::from_bytes_with_nul_unchecked(
@@ -428,7 +428,7 @@ macro_rules! py_capsule_fn {
                 }
             }
 
-            pub fn retrieve(py: $crate::Python) -> $crate::PyResult<CapsFn> {
+            pub fn retrieve(py: $crate::Python) -> $crate::PyResult<CapsuleFn> {
                 unsafe {
                     INIT.call_once(|| { CAPS_FN = Some(import(py)) });
                     match CAPS_FN.as_ref().unwrap() {

--- a/src/objects/capsule.rs
+++ b/src/objects/capsule.rs
@@ -1,0 +1,286 @@
+//! Work wih Python capsules
+//!
+use super::object::PyObject;
+use err::{self, PyErr, PyResult};
+use ffi::{PyCapsule_GetPointer, PyCapsule_Import, PyCapsule_New};
+use libc::c_void;
+use python::{Python, ToPythonPointer};
+use std::ffi::{CStr, CString, NulError};
+use std::mem;
+
+/// Represents a Python capsule object.
+pub struct PyCapsule(PyObject);
+
+pyobject_newtype!(PyCapsule, PyCapsule_CheckExact, PyCapsule_Type);
+
+/// Capsules are the preferred way to export/import C APIs between extension modules,
+/// see [Providing a C API for an Extension Module](https://docs.python.org/3/extending/extending.html#using-capsules).
+///
+/// In particular, capsules can be very useful to start adding Rust extensions besides
+/// existing traditional C ones, be it for gradual rewrites or to extend with new functionality.
+/// They can also be used for interaction between independently compiled Rust extensions if needed.
+///
+/// # Examples
+/// ## Using a capsule defined in another extension module
+/// This retrieves and use one of the simplest capsules in the Python standard library, found in
+/// the `unicodedata` module. The C API enclosed in this capsule is the same for all Python
+/// versions supported by this crate. This is not the case of all capsules from the standard
+/// library. For instance the `struct` referenced by `datetime.datetime_CAPI` gets a new member
+/// in version 3.7.
+///
+/// ```
+/// #[macro_use] extern crate cpython;
+/// extern crate libc;
+///
+/// use cpython::{Python, PyCapsule};
+/// use libc::{c_char, c_int};
+/// use std::ffi::{c_void, CStr, CString};
+/// use std::mem;
+/// use std::ptr::null_mut;
+///
+/// #[allow(non_camel_case_types)]
+/// type Py_UCS4 = u32;
+/// const UNICODE_NAME_MAXLEN: usize = 256;
+///
+/// #[repr(C)]
+/// pub struct unicode_name_CAPI {
+///     // the `ucd` signature arguments are actually optional (can be `NULL`) FFI PyObject
+///     // pointers used to pass alternate (former) versions of Unicode data.
+///     // We won't need to use them with an actual value in these examples, so it's enough to
+///     // specify them as `*mut c_void`, and it spares us a direct reference to the lower
+///     // level Python FFI bindings.
+///     size: c_int,
+///     getname: unsafe extern "C" fn(
+///         ucd: *mut c_void,
+///         code: Py_UCS4,
+///         buffer: *mut c_char,
+///         buflen: c_int,
+///         with_alias_and_seq: c_int,
+///     ) -> c_int,
+///     getcode: unsafe extern "C" fn(
+///         ucd: *mut c_void,
+///         name: *const c_char,
+///         namelen: c_int,
+///         code: *mut Py_UCS4,
+///     ) -> c_int,
+/// }
+
+/// #[derive(Debug, PartialEq)]
+/// pub enum UnicodeDataError {
+///     InvalidCode,
+///     UnknownName,
+/// }
+/// impl unicode_name_CAPI {
+///     pub fn get_name(&self, code: Py_UCS4) -> Result<CString, UnicodeDataError> {
+///         let mut buf: Vec<c_char> = Vec::with_capacity(UNICODE_NAME_MAXLEN);
+///         let buf_ptr = buf.as_mut_ptr();
+///         if unsafe {
+///           ((*self).getname)(null_mut(), code, buf_ptr, UNICODE_NAME_MAXLEN as c_int, 0)
+///         } != 1 {
+///             return Err(UnicodeDataError::InvalidCode);
+///         }
+///         mem::forget(buf);
+///         Ok(unsafe { CString::from_raw(buf_ptr) })
+///     }
+///
+///     pub fn get_code(&self, name: &CStr) -> Result<Py_UCS4, UnicodeDataError> {
+///         let namelen = name.to_bytes().len() as c_int;
+///         let mut code: [Py_UCS4; 1] = [0; 1];
+///         if unsafe {
+///             ((*self).getcode)(null_mut(), name.as_ptr(), namelen, code.as_mut_ptr())
+///         } != 1 {
+///             return Err(UnicodeDataError::UnknownName);
+///         }
+///         Ok(code[0])
+///     }
+/// }
+///
+/// let gil = Python::acquire_gil();
+/// let py = gil.python();
+///
+/// let capi: &unicode_name_CAPI = unsafe {
+///     PyCapsule::import_data(
+///         py,
+///         CStr::from_bytes_with_nul_unchecked(b"unicodedata.ucnhash_CAPI\0"),
+///     )
+/// }
+/// .unwrap();
+///
+/// assert_eq!(capi.get_name(32).unwrap().to_str(), Ok("SPACE"));
+/// assert_eq!(capi.get_name(0), Err(UnicodeDataError::InvalidCode));
+///
+/// assert_eq!(
+///     capi.get_code(CStr::from_bytes_with_nul(b"COMMA\0").unwrap()),
+///     Ok(44)
+/// );
+/// assert_eq!(
+///     capi.get_code(CStr::from_bytes_with_nul(b"\0").unwrap()),
+///     Err(UnicodeDataError::UnknownName)
+/// );
+/// ```
+///
+/// ## Creating a capsule from Rust
+/// In this example, we enclose some data and a function in a capsule, using an intermediate
+/// `struct` as enclosing type, then retrieve them back and use them.
+///
+/// ```
+/// extern crate cpython;
+/// extern crate libc;
+///
+/// use libc::c_int;
+/// use cpython::{PyCapsule, Python};
+/// use std::ffi::{c_void, CStr, CString};
+///
+/// #[repr(C)]
+/// struct CapsData {
+///     value: c_int,
+///     fun: fn(c_int, c_int) -> c_int,
+/// }
+///
+/// fn add(a: c_int, b: c_int) -> c_int {
+///     a + b
+/// }
+///
+/// const DATA: CapsData = CapsData{value: 1, fun: add};
+///
+/// let gil = Python::acquire_gil();
+/// let py = gil.python();
+/// let caps = PyCapsule::new_data(py, &mut DATA, "somemod.capsdata").unwrap();
+///
+/// let retrieved: &CapsData = unsafe {caps.data_ref("somemod.capsdata")}.unwrap();
+/// assert_eq!(retrieved.value, 1);
+/// assert_eq!((retrieved.fun)(2 as c_int, 3 as c_int), 5);
+/// ```
+///
+/// Of course, a more realistic example would be to store the capsule in a Python module,
+/// allowing another extension (possibly foreign) to retrieve and use it.
+/// Note that in that case, the capsule `name` must be full dotted name of the capsule object,
+/// as we're doing here.
+/// ```
+/// # #[macro_use] extern crate cpython;
+/// # extern crate libc;
+/// # use libc::c_int;
+/// # use cpython::PyCapsule;
+/// # #[repr(C)]
+/// # struct CapsData {
+/// #     value: c_int,
+/// #     fun: fn(c_int, c_int) -> c_int,
+/// # }
+/// # fn add(a: c_int, b: c_int) -> c_int {
+/// #     a + b
+/// # }
+/// # const DATA: CapsData = CapsData{value: 1, fun: add};
+/// py_module_initializer!(somemod, initsomemod, PyInit_somemod, |py, m| {
+///   m.add(py, "__doc__", "A module holding a capsule")?;
+///   m.add(py, "capsdata", PyCapsule::new_data(py, &mut DATA, "somemod.capsdata").unwrap())?;
+///   Ok(())
+/// });
+/// ```
+/// Another Rust extension could then declare `CapsData` and use `PyCapsule::import_data` to
+/// fetch it back.
+impl PyCapsule {
+    /// Retrieve the contents of a capsule pointing to some data as a reference.
+    ///
+    /// The retrieved data would typically be an array of static data and/or function pointers.
+    /// This method doesn't work for standalone function pointers.
+    ///
+    /// # Safety
+    /// This method is unsafe, because
+    /// - nothing guarantees that the `T` type is appropriate for the data referenced by the capsule
+    ///   pointer
+    /// - the returned lifetime doesn't guarantee either to cover the actual lifetime of the data
+    ///   (although capsule data is usually static)
+    pub unsafe fn import_data<'a, T>(py: Python, name: &CStr) -> PyResult<&'a T> {
+        Ok(&*(Self::import(py, name)? as *const T))
+    }
+
+    /// Retrieves the contents of a capsule as a void pointer by its name.
+    ///
+    /// This is suitable in particular for later conversion as a function pointer
+    /// with `mem::transmute`, for architectures where data and function pointers have
+    /// the same size (see details about this the documentation of the Rust standard library).
+    pub fn import(py: Python, name: &CStr) -> PyResult<*mut c_void> {
+        let caps_ptr = unsafe { PyCapsule_Import(name.as_ptr(), 0) };
+        if caps_ptr.is_null() {
+            return Err(PyErr::fetch(py));
+        }
+        Ok(caps_ptr)
+    }
+
+    /// Convenience method to create a capsule for some data
+    ///
+    /// The encapsuled data may be an array of functions, but it can't be itself a
+    /// function directly.
+    ///
+    /// May panic when running out of memory.
+    ///
+    pub fn new_data<T>(
+        py: Python,
+        data: &mut T,
+        name: impl Into<Vec<u8>>,
+    ) -> Result<Self, NulError> {
+        Self::new(py, data as *mut T as *mut c_void, name)
+    }
+
+    /// Creates a new capsule from a raw void pointer
+    ///
+    /// This is suitable in particular to store a function pointer in a capsule. These
+    /// can be obtained simply by a simple cast:
+    ///
+    /// ```
+    /// extern crate libc;
+    /// use libc::c_void;
+    ///
+    /// extern "C" fn inc(a: i32) -> i32 {
+    ///     a + 1
+    /// }
+    /// let ptr = inc as *mut c_void;
+    /// ```
+    ///
+    /// # Errors
+    /// This method returns `NulError` if `name` contains a 0 byte (see also `CString::new`)
+    pub fn new(
+        py: Python,
+        pointer: *mut c_void,
+        name: impl Into<Vec<u8>>,
+    ) -> Result<Self, NulError> {
+        let name = CString::new(name)?;
+        let caps = unsafe {
+            Ok(err::cast_from_owned_ptr_or_panic(
+                py,
+                PyCapsule_New(pointer, name.as_ptr(), None),
+            ))
+        };
+        // it is required that the capsule name outlives the call as a char*
+        // TODO implement a proper PyCapsule_Destructor to release it properly
+        mem::forget(name);
+        caps
+    }
+
+    /// Returns a reference to the capsule data.
+    ///
+    /// The name must match exactly the one given at capsule creation time (see `new_data`) and
+    /// is converted to a C string under the hood. If that's too much overhead, consider using
+    /// `data_ref_cstr()` or caching strategies.
+    ///
+    /// This is unsafe, because
+    /// - nothing guarantees that the `T` type is appropriate for the data referenced by the capsule
+    ///   pointer
+    /// - the returned lifetime doesn't guarantee either to cover the actual lifetime of the data
+    ///   (although capsule data is usually static)
+    ///
+    /// # Errors
+    /// This method returns `NulError` if `name` contains a 0 byte (see also `CString::new`)
+    pub unsafe fn data_ref<'a, T>(&self, name: impl Into<Vec<u8>>) -> Result<&'a T, NulError> {
+        Ok(self.data_ref_cstr(&CString::new(name)?))
+    }
+
+    /// Returns a reference to the capsule data.
+    ///
+    /// This is identical to `data_ref`, except for the name passing. This allows to use
+    /// lower level constructs without overhead, such as `CStr::from_bytes_with_nul_unchecked`
+    /// or the `cstr!` macro of `rust-cpython`
+    pub unsafe fn data_ref_cstr<'a, T>(&self, name: &CStr) -> &'a T {
+        &*(PyCapsule_GetPointer(self.as_ptr(), name.as_ptr()) as *const T)
+    }
+}

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -37,6 +37,7 @@ pub use self::num::PyInt;
 pub use self::num::PyLong as PyInt;
 pub use self::num::{PyLong, PyFloat};
 pub use self::sequence::PySequence;
+pub use self::capsule::PyCapsule;
 
 #[macro_export]
 macro_rules! pyobject_newtype(
@@ -132,6 +133,7 @@ mod tuple;
 mod list;
 mod num;
 mod sequence;
+mod capsule;
 pub mod exc;
 
 #[cfg(feature="python27-sys")]


### PR DESCRIPTION
Python Capsules are the preferred way to export / import C-level APIs between extension modules (see https://docs.python.org/3/c-api/capsule.html). I believe them to be key for incremental switch to Rust of existing C extensions.

The first commit introduces the `PyCapsule` struct (based on symbols already provided by `python-sys`), the two subsequent ones add macros that take care of the direct function pointer case and caching using `sync::Once` on a `static mut`