### PR TITLE
Use rustup.rs to install Rust in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,25 @@ python:
 env:
   - RUST_VERSION=1.25.0
   - RUST_VERSION=nightly
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial
+      sudo: true
+      env: RUST_VERSION=1.25.0
+    - python: "3.7"
+      dist: xenial
+      sudo: true
+      env: RUST_VERSION=nightly
 sudo: false
 install:
   - python -c "import sysconfig; print('\n'.join(map(repr,sorted(sysconfig.get_config_vars().items()))))"
-  - mkdir ~/rust-installer
-  - curl -sL https://static.rust-lang.org/rustup.sh -o ~/rust-installer/rustup.sh
-  - sh ~/rust-installer/rustup.sh --prefix=~/rust --spec=$RUST_VERSION -y --disable-sudo
-  - export PATH="$HOME/rust/bin:$PATH"
+  - curl -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain "$RUST_VERSION"
+  - export PATH="$HOME/.cargo/bin:$PATH"
   - export PYTHON_LIB=$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
   - find $PYTHON_LIB
   - export LIBRARY_PATH="$LIBRARY_PATH:$PYTHON_LIB"
-  - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PYTHON_LIB:$HOME/rust/lib"
+  - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PYTHON_LIB"
   - rustc -V
 script:
   - make test extensions


### PR DESCRIPTION
The old Rust installer has been replaced with rustup.rs.  Use this to
install Rust in Travis.