### PR TITLE
Add basic support for osx builds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,15 @@ matrix:
       dist: xenial
       sudo: true
       env: RUST_VERSION=nightly
+    - os: osx
+      language: generic
+      env: RUST_VERSION=1.25.0
+    - os: osx
+      language: generic
+      env: RUST_VERSION=nightly
 sudo: false
 install:
+  - python -V
   - python -c "import sysconfig; print('\n'.join(map(repr,sorted(sysconfig.get_config_vars().items()))))"
   - curl -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain "$RUST_VERSION"
   - export PATH="$HOME/.cargo/bin:$PATH"

--- a/tests/check_symbols.py
+++ b/tests/check_symbols.py
@@ -14,7 +14,8 @@ if platform.system() == 'Windows' or platform.system().startswith('CYGWIN'):
 
 so_files = [
     sysconfig.get_config_var("LIBDIR")+"/"+sysconfig.get_config_var("LDLIBRARY"),
-    sysconfig.get_config_var("LIBPL")+"/"+sysconfig.get_config_var("LDLIBRARY")
+    sysconfig.get_config_var("LIBPL")+"/"+sysconfig.get_config_var("LDLIBRARY"),
+    sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX")+"/"+sysconfig.get_config_var("LDLIBRARY"),
 ]
 so_file = None
 for name in so_files:


### PR DESCRIPTION
Based on https://github.com/dgrunwald/rust-cpython/pull/86

For simplicity, we just use the system Python for osx.