### PR TITLE
doc(readme) Fix the extension example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ use cpython::{PyResult, Python};
 
 // add bindings to the generated python module
 // N.B: names: "librust2py" must be the name of the `.so` or `.pyd` file
-py_module_initializer!(librust2py, initlibrust2py, PyInit_librust2py, |py, m| {
+py_module_initializer!(librust2py, initlibrust2py, PyInit_rust2py, |py, m| {
     m.add(py, "__doc__", "This module is implemented in Rust.")?;
     m.add(py, "sum_as_string", py_fn!(py, sum_as_string_py(a: i64, b:i64)))?;
     Ok(())


### PR DESCRIPTION
Thanks for the great project!

Without this patch, the example were not working on my computer with Python 3. I hope it's OK!