### PR TITLE
Make cf_flags in PyCompilerFlags pub

### DIFF
--- a/python27-sys/src/pythonrun.rs
+++ b/python27-sys/src/pythonrun.rs
@@ -15,7 +15,7 @@ pub const PyCF_ONLY_AST : c_int = 0x0400;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyCompilerFlags {
-    cf_flags : c_int
+    pub cf_flags : c_int
 }
 
 #[allow(missing_copy_implementations)]

--- a/python3-sys/src/pythonrun.rs
+++ b/python3-sys/src/pythonrun.rs
@@ -28,7 +28,7 @@ use pyarena::PyArena;
 #[derive(Copy, Clone)]
 #[cfg(not(Py_LIMITED_API))]
 pub struct PyCompilerFlags {
-    cf_flags : c_int
+    pub cf_flags : c_int
 }
 
 #[cfg(not(Py_LIMITED_API))]


### PR DESCRIPTION
Otherwise we can't set this field when instantiating the struct outside of the module.