### PR TITLE
Implement data marshalling module for python3-sys

### DIFF
--- a/python27-sys/src/lib.rs
+++ b/python27-sys/src/lib.rs
@@ -56,6 +56,7 @@ pub use compile::*;
 pub use eval::*;
 pub use structmember::PyMemberDef;
 pub use frameobject::PyFrameObject;
+pub use marshal::*;
 
 mod pyport;
 mod pymem;
@@ -114,6 +115,7 @@ mod objectabstract;
 mod code;
 mod compile;
 mod eval;
+mod marshal;
 
 // mod pyctype; // TODO: incomplete
 // mod pystrtod; // TODO: incomplete

--- a/python27-sys/src/marshal.rs
+++ b/python27-sys/src/marshal.rs
@@ -1,0 +1,27 @@
+use libc::{c_char, c_int, c_long, FILE};
+use object::PyObject;
+use pyport::Py_ssize_t;
+
+// 1 -> 2 in df88846ebca9186514e86bc2067242233ade4608 (Python 2.5)
+pub const Py_MARSHAL_VERSION: c_int = 2;
+
+#[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
+    pub fn PyMarshal_WriteLongToFile(arg1: c_long,
+                                     arg2: *mut FILE,
+                                     arg3: c_int);
+    pub fn PyMarshal_WriteObjectToFile(arg1: *mut PyObject,
+                                       arg2: *mut FILE,
+                                       arg3: c_int);
+    pub fn PyMarshal_WriteObjectToString(arg1: *mut PyObject,
+                                         arg2: c_int) -> *mut PyObject;
+    pub fn PyMarshal_ReadObjectFromString(arg1: *const c_char,
+                                          arg2: Py_ssize_t) -> *mut PyObject;
+}
+
+#[cfg(not(Py_LIMITED_API))]
+#[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
+    pub fn PyMarshal_ReadLongFromFile(arg1: *mut FILE) -> c_long;
+    pub fn PyMarshal_ReadShortFromFile(arg1: *mut FILE) -> c_int;
+    pub fn PyMarshal_ReadObjectFromFile(arg1: *mut FILE) -> *mut PyObject;
+    pub fn PyMarshal_ReadLastObjectFromFile(arg1: *mut FILE) -> *mut PyObject;
+}

--- a/python3-sys/src/lib.rs
+++ b/python3-sys/src/lib.rs
@@ -72,6 +72,7 @@ pub use eval::*;
 
 pub use pystrtod::*;
 pub use frameobject::PyFrameObject;
+pub use marshal::*;
 
 mod pyport;
 // mod pymacro; contains nothing of interest for Rust
@@ -169,3 +170,4 @@ pub mod frameobject {
     pub enum PyFrameObject {}
 }
 
+mod marshal;

--- a/python3-sys/src/marshal.rs
+++ b/python3-sys/src/marshal.rs
@@ -1,0 +1,33 @@
+use libc::{c_char, c_int, c_long, FILE};
+use object::PyObject;
+use pyport::Py_ssize_t;
+
+// 1 -> 2 in df88846ebca9186514e86bc2067242233ade4608 (Python 2.5)
+// 2 -> 3 in d7009c69136a3809282804f460902ab42e9972f6 (Python 3.4)
+// 3 -> 4 in 1164dfcb86757ebaeb68276e4b8f6ee266c9968d (Python 3.4)
+#[cfg(all(Py_3_3, not(Py_3_4)))]
+pub const Py_MARSHAL_VERSION: c_int = 2;
+
+#[cfg(Py_3_4)]
+pub const Py_MARSHAL_VERSION: c_int = 4;
+
+#[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
+    pub fn PyMarshal_WriteLongToFile(arg1: c_long,
+                                     arg2: *mut FILE,
+                                     arg3: c_int);
+    pub fn PyMarshal_WriteObjectToFile(arg1: *mut PyObject,
+                                       arg2: *mut FILE,
+                                       arg3: c_int);
+    pub fn PyMarshal_WriteObjectToString(arg1: *mut PyObject,
+                                         arg2: c_int) -> *mut PyObject;
+    pub fn PyMarshal_ReadObjectFromString(arg1: *const c_char,
+                                          arg2: Py_ssize_t) -> *mut PyObject;
+}
+
+#[cfg(not(Py_LIMITED_API))]
+#[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
+    pub fn PyMarshal_ReadLongFromFile(arg1: *mut FILE) -> c_long;
+    pub fn PyMarshal_ReadShortFromFile(arg1: *mut FILE) -> c_int;
+    pub fn PyMarshal_ReadObjectFromFile(arg1: *mut FILE) -> *mut PyObject;
+    pub fn PyMarshal_ReadLastObjectFromFile(arg1: *mut FILE) -> *mut PyObject;
+}


### PR DESCRIPTION
I had a need for some of these APIs in a project. I went ahead and implemented the full `marshal.h` interface.