### PR TITLE
Docstrings in static and class methods

### DIFF
--- a/src/py_class/members.rs
+++ b/src/py_class/members.rs
@@ -119,6 +119,10 @@ impl <T> TypeMember<T> for InstanceMethodDescriptor<T> where T: PythonObject {
 #[doc(hidden)]
 macro_rules! py_class_class_method {
     ($py:ident, $class:ident :: $f:ident [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]) => {{
+        py_class_class_method!($py, $class::$f, { "" } [ $( { $pname : $ptype = $detail } )* ])
+    }};
+
+    ($py:ident, $class:ident :: $f:ident, { $doc:expr } [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]) => {{
         unsafe extern "C" fn wrap_class_method(
             cls: *mut $crate::_detail::ffi::PyObject,
             args: *mut $crate::_detail::ffi::PyObject,
@@ -142,7 +146,8 @@ macro_rules! py_class_class_method {
         unsafe {
             let method_def = py_method_def!(_cpython__py_class__members__stringify!($f),
                 $crate::_detail::ffi::METH_CLASS,
-                wrap_class_method);
+                wrap_class_method,
+                $doc);
             $crate::py_class::members::create_class_method_descriptor(method_def)
         }
     }}
@@ -169,6 +174,10 @@ impl <T> TypeMember<T> for ClassMethodDescriptor where T: PythonObject {
 #[doc(hidden)]
 macro_rules! py_class_static_method {
     ($py:ident, $class:ident :: $f:ident [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]) => {{
+        py_class_static_method!($py, $class::$f, { "" } [ $( { $pname : $ptype = $detail } )* ])
+    }};
+
+    ($py:ident, $class:ident :: $f:ident, { $doc:expr } [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]) => {{
         unsafe extern "C" fn wrap_static_method(
             _slf: *mut $crate::_detail::ffi::PyObject,
             args: *mut $crate::_detail::ffi::PyObject,
@@ -189,7 +198,8 @@ macro_rules! py_class_static_method {
         unsafe {
             let method_def = py_method_def!(_cpython__py_class__members__stringify!($f),
                 $crate::_detail::ffi::METH_STATIC,
-                wrap_static_method);
+                wrap_static_method,
+                $doc);
             $crate::_detail::py_fn_impl($py, method_def)
         }
     }}

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -1743,7 +1743,7 @@ macro_rules! py_class_impl {
             $name = py_argparse_parse_plist_impl!{py_class_instance_method {$py, $class::$name, { _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*) }} [] ($($p)+,)};
         }
     }};
-    { { @classmethod def $name:ident ($cls:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+    { { $(#[doc=$doc:expr])*@classmethod def $name:ident ($cls:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
         { $( $member_name:ident = $member_expr:expr; )* }
@@ -1756,10 +1756,10 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name = py_class_class_method!{$py, $class::$name []};
+            $name = py_class_class_method!{$py, $class::$name, { _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*) } []};
         }
     }};
-    { { @classmethod def $name:ident ($cls:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+    { { $(#[doc=$doc:expr])*@classmethod def $name:ident ($cls:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
         { $( $member_name:ident = $member_expr:expr; )* }
@@ -1775,10 +1775,10 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name = py_argparse_parse_plist_impl!{py_class_class_method {$py, $class::$name} [] ($($p)+,)};
+            $name = py_argparse_parse_plist_impl!{py_class_class_method {$py, $class::$name, { _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*) }} [] ($($p)+,)};
         }
     }};
-    { { @staticmethod def $name:ident ($($p:tt)*) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+    { { $(#[doc=$doc:expr])* @staticmethod def $name:ident ($($p:tt)*) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
         { $( $member_name:ident = $member_expr:expr; )* }
@@ -1796,7 +1796,9 @@ macro_rules! py_class_impl {
             $( $member_name = $member_expr; )*
             $name = 
             py_argparse_parse_plist!{
-                py_class_static_method {$py, $class::$name}
+                py_class_static_method {$py, $class::$name, {
+                    _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*)
+                    } }
                 ($($p)*)
             }
             ;

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -1743,7 +1743,7 @@ macro_rules! py_class_impl {
             $name = py_argparse_parse_plist_impl!{py_class_instance_method {$py, $class::$name, { _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*) }} [] ($($p)+,)};
         }
     }};
-    { { @classmethod def $name:ident ($cls:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+    { { $(#[doc=$doc:expr])*@classmethod def $name:ident ($cls:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
         { $( $member_name:ident = $member_expr:expr; )* }
@@ -1756,10 +1756,10 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name = py_class_class_method!{$py, $class::$name []};
+            $name = py_class_class_method!{$py, $class::$name, { _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*) } []};
         }
     }};
-    { { @classmethod def $name:ident ($cls:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+    { { $(#[doc=$doc:expr])*@classmethod def $name:ident ($cls:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
         { $( $member_name:ident = $member_expr:expr; )* }
@@ -1775,10 +1775,10 @@ macro_rules! py_class_impl {
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
-            $name = py_argparse_parse_plist_impl!{py_class_class_method {$py, $class::$name} [] ($($p)+,)};
+            $name = py_argparse_parse_plist_impl!{py_class_class_method {$py, $class::$name, { _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*) }} [] ($($p)+,)};
         }
     }};
-    { { @staticmethod def $name:ident ($($p:tt)*) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+    { { $(#[doc=$doc:expr])* @staticmethod def $name:ident ($($p:tt)*) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
         { $( $member_name:ident = $member_expr:expr; )* }
@@ -1796,7 +1796,9 @@ macro_rules! py_class_impl {
             $( $member_name = $member_expr; )*
             $name = 
             py_argparse_parse_plist!{
-                py_class_static_method {$py, $class::$name}
+                py_class_static_method {$py, $class::$name, {
+                    _cpython__py_class__py_class_impl__concat!($($doc, "\n"),*)
+                    } }
                 ($($p)*)
             }
             ;


### PR DESCRIPTION
https://github.com/dgrunwald/rust-cpython/pull/166 continued.

Support for docstrings in class methods and static methods. Slots (special methods) are still not supported and I don't see any way to implement it with Python C API.
