### PR TITLE
py_class: support Rust raw identifiers for method and keyword names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,21 @@ python:
   - "3.5"
   - "3.6"
 env:
-  - RUST_VERSION=1.25.0
+  - RUST_VERSION=1.30.0
   - RUST_VERSION=nightly
 matrix:
   include:
     - python: "3.7"
       dist: xenial
       sudo: true
-      env: RUST_VERSION=1.25.0
+      env: RUST_VERSION=1.30.0
     - python: "3.7"
       dist: xenial
       sudo: true
       env: RUST_VERSION=nightly
     - os: osx
       language: generic
-      env: RUST_VERSION=1.25.0
+      env: RUST_VERSION=1.30.0
     - os: osx
       language: generic
       env: RUST_VERSION=nightly

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supported Python versions:
 * Python 2.7
 * Python 3.3 to 3.7
 
-Requires Rust 1.25.0 or later.
+Requires Rust 1.30.0 or later.
 
 # Usage
 

--- a/python3-sys/src/pyerrors.rs
+++ b/python3-sys/src/pyerrors.rs
@@ -111,7 +111,7 @@ pub unsafe fn PyExceptionInstance_Class(x: *mut PyObject) -> *mut PyObject {
     pub static mut PyExc_EnvironmentError: *mut PyObject;
     pub static mut PyExc_IOError: *mut PyObject;
     #[cfg(windows)] pub static mut PyExc_WindowsError: *mut PyObject;
-    #[cfg(not(Py_3_7))] pub static mut PyExc_RecursionErrorInst: *mut PyObject;
+    #[cfg(not(Py_3_6))] pub static mut PyExc_RecursionErrorInst: *mut PyObject;
 
     // Predefined warning categories
     pub static mut PyExc_Warning: *mut PyObject;

--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -34,6 +34,17 @@ pub struct ParamDescription<'a> {
     pub is_optional: bool
 }
 
+impl<'a> ParamDescription<'a> {
+    /// Name, with leading `r#` stripped.
+    pub fn name(&self) -> &str {
+        if self.name.starts_with("r#") {
+            &self.name[2..]
+        } else {
+            self.name
+        }
+    }
+}
+
 /// Parse argument list
 ///
 ///  * fname:  Name of the current function
@@ -65,14 +76,14 @@ pub fn parse_args(
     let mut used_keywords = 0;
     // Iterate through the parameters and assign values to output:
     for (i, (p, out)) in params.iter().zip(output).enumerate() {
-        match kwargs.and_then(|d| d.get_item(py, p.name)) {
+        match kwargs.and_then(|d| d.get_item(py, p.name())) {
             Some(kwarg) => {
                 *out = Some(kwarg);
                 used_keywords += 1;
                 if i < nargs {
                     return Err(err::PyErr::new::<exc::TypeError, _>(py,
                         format!("Argument given by name ('{}') and position ({})",
-                                p.name, i+1)));
+                                p.name(), i+1)));
                 }
             },
             None => {
@@ -83,7 +94,7 @@ pub fn parse_args(
                     if !p.is_optional {
                         return Err(err::PyErr::new::<exc::TypeError, _>(py,
                             format!("Required argument ('{}') (pos {}) not found",
-                                    p.name, i+1)));
+                                    p.name(), i+1)));
                     }
                 }
             }

--- a/src/function.rs
+++ b/src/function.rs
@@ -42,6 +42,9 @@ macro_rules! py_method_def {
             ml_doc: 0 as *const $crate::_detail::libc::c_char
         };
         METHOD_DEF.ml_name = concat!($name, "\0").as_ptr() as *const _;
+        if $name.starts_with("r#") {
+            METHOD_DEF.ml_name = METHOD_DEF.ml_name.add(2);
+        }
         if !$doc.is_empty() {
             METHOD_DEF.ml_doc = concat!($doc, "\0").as_ptr() as *const _;
         }

--- a/src/py_class/members.rs
+++ b/src/py_class/members.rs
@@ -55,7 +55,13 @@ macro_rules! py_class_init_members {
             let descriptor = unsafe {
                 $crate::py_class::members::TypeMember::<$class>::into_descriptor(init, $py, &mut $type_object)
             }?;
-            dict.set_item($py, stringify!($name), descriptor)?;
+            let name = stringify!($name);
+            let name = if name.starts_with("r#") {
+                &name[2..]
+            } else {
+                name
+            };
+            dict.set_item($py, name, descriptor)?;
         })*
         unsafe {
             assert!($type_object.tp_dict.is_null());

--- a/tests/test_class.rs
+++ b/tests/test_class.rs
@@ -166,6 +166,10 @@ py_class!(class InstanceMethodWithArgs |py| {
     def method(&self, multiplier: i32) -> PyResult<i32> {
         Ok(*self.member(py) * multiplier)
     }
+
+    def r#match(&self, r#match: i32) -> PyResult<i32> {
+        Ok(r#match)
+    }
 });
 
 #[test]
@@ -179,6 +183,7 @@ fn instance_method_with_args() {
     d.set_item(py, "obj", obj).unwrap();
     py.run("assert obj.method(3) == 21", None, Some(&d)).unwrap();
     py.run("assert obj.method(multiplier=6) == 42", None, Some(&d)).unwrap();
+    py.run("assert obj.match(match=3) == 3", None, Some(&d)).unwrap();
 }
 
 py_class!(class ClassMethod |py| {


### PR DESCRIPTION
Make it possible to use Rust keywords for keyword argument and method names.