### PR TITLE
Support Python 3.8 in python3-sys.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,13 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 env:
   - RUST_VERSION=1.30.0
   - RUST_VERSION=nightly
 matrix:
   include:
-    - python: "3.7"
-      dist: xenial
-      sudo: true
-      env: RUST_VERSION=1.30.0
-    - python: "3.7"
-      dist: xenial
-      sudo: true
-      env: RUST_VERSION=nightly
     - os: osx
       language: generic
       env: RUST_VERSION=1.30.0
@@ -27,7 +21,7 @@ sudo: false
 install:
   - python -V
   - python -c "import sysconfig; print('\n'.join(map(repr,sorted(sysconfig.get_config_vars().items()))))"
-  - curl -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain "$RUST_VERSION"
+  - curl -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile=minimal --default-toolchain "$RUST_VERSION"
   - export PATH="$HOME/.cargo/bin:$PATH"
   - export PYTHON_LIB=$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
   - find $PYTHON_LIB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+- Added Python 3.8 support
 
 [Unreleased]: https://github.com/dgrunwald/rust-cpython/compare/0.3.0...HEAD
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ extension-module-2-7 = [ "python27-sys/extension-module" ]
 # Optional features to support explicitly specifying python minor version.
 # If you don't care which minor version, just specify python3-sys as a 
 # feature.
+python-3-8 = ["python3-sys/python-3-8"]
 python-3-7 = ["python3-sys/python-3-7"]
 python-3-6 = ["python3-sys/python-3-6"]
 python-3-5 = ["python3-sys/python-3-5"]

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ rust-cpython [![Build Status](https://travis-ci.org/dgrunwald/rust-cpython.svg?b
 
 ---
 
-Copyright (c) 2015-2017 Daniel Grunwald.
+Copyright (c) 2015-2019 Daniel Grunwald.
 Rust-cpython is licensed under the [MIT license](http://opensource.org/licenses/MIT).
 Python is licensed under the [Python License](https://docs.python.org/2/license.html).
 
 Supported Python versions:
 * Python 2.7
-* Python 3.3 to 3.7
+* Python 3.3 to 3.8
 
 Requires Rust 1.30.0 or later.
 

--- a/python3-sys/Cargo.toml
+++ b/python3-sys/Cargo.toml
@@ -45,6 +45,7 @@ python-3-4 = []
 python-3-5 = []
 python-3-6 = []
 python-3-7 = []
+python-3-8 = []
 
 # Restrict to PEP-384 stable ABI
 pep-384 = []

--- a/python3-sys/src/ceval.rs
+++ b/python3-sys/src/ceval.rs
@@ -61,6 +61,7 @@ pub unsafe fn PyEval_CallObject(callable: *mut PyObject, arg: *mut PyObject) -> 
     pub fn PyEval_ReleaseLock() -> ();
     pub fn PyEval_AcquireThread(tstate: *mut PyThreadState) -> ();
     pub fn PyEval_ReleaseThread(tstate: *mut PyThreadState) -> ();
+    #[cfg(not(Py_3_8))]
     pub fn PyEval_ReInitThreads() -> ();
 }
 

--- a/python3-sys/src/code.rs
+++ b/python3-sys/src/code.rs
@@ -3,11 +3,16 @@ use libc::{c_void, c_uchar, c_char, c_int};
 use pyport::Py_ssize_t;
 use object::*;
 
+#[cfg(Py_3_8)]
+pub enum  _PyOpcache {}
+
 #[repr(C)]
 #[derive(Copy)]
 pub struct PyCodeObject {
     pub ob_base: PyObject,
     pub co_argcount: c_int,
+    #[cfg(Py_3_8)]
+    pub co_posonlyargcount: c_int,
     pub co_kwonlyargcount: c_int,
     pub co_nlocals: c_int,
     pub co_stacksize: c_int,
@@ -33,6 +38,14 @@ pub struct PyCodeObject {
     pub co_weakreflist: *mut PyObject,
     #[cfg(Py_3_6)]
     pub co_extra: *mut c_void,
+    #[cfg(Py_3_8)]
+    pub co_opcache_map: *mut c_uchar,
+    #[cfg(Py_3_8)]
+    pub co_opcache: *mut _PyOpcache,
+    #[cfg(Py_3_8)]
+    pub co_opcache_flag: c_int,
+    #[cfg(Py_3_8)]
+    pub co_opcache_size: c_uchar,
 }
 impl Clone for PyCodeObject {
     #[inline] fn clone(&self) -> Self { *self }
@@ -84,14 +97,27 @@ pub const CO_MAXBLOCKS: usize = 20;
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
     pub static mut PyCode_Type: PyTypeObject;
 
-    pub fn PyCode_New(arg1: c_int, arg2: c_int,
-                      arg3: c_int, arg4: c_int,
-                      arg5: c_int, arg6: *mut PyObject,
-                      arg7: *mut PyObject, arg8: *mut PyObject,
-                      arg9: *mut PyObject, arg10: *mut PyObject,
-                      arg11: *mut PyObject, arg12: *mut PyObject,
-                      arg13: *mut PyObject, arg14: c_int,
-                      arg15: *mut PyObject) -> *mut PyCodeObject;
+    pub fn PyCode_New(argcount: c_int, kwonlyargcount: c_int,
+                      nlocals: c_int, stacksize: c_int,
+                      flags: c_int, code: *mut PyObject,
+                      consts: *mut PyObject, names: *mut PyObject,
+                      varnames: *mut PyObject, freevars: *mut PyObject,
+                      cellvars: *mut PyObject, filename: *mut PyObject,
+                      name: *mut PyObject, firstlineno: c_int,
+                      lnotab: *mut PyObject) -> *mut PyCodeObject;
+
+    #[cfg(Py_3_8)]
+    pub fn PyCode_NewWithPosOnlyArgs(argcount: c_int,
+                      posonlyargcount: c_int,
+                      kwonlyargcount: c_int,
+                      nlocals: c_int, stacksize: c_int,
+                      flags: c_int, code: *mut PyObject,
+                      consts: *mut PyObject, names: *mut PyObject,
+                      varnames: *mut PyObject, freevars: *mut PyObject,
+                      cellvars: *mut PyObject, filename: *mut PyObject,
+                      name: *mut PyObject, firstlineno: c_int,
+                      lnotab: *mut PyObject) -> *mut PyCodeObject;
+
     pub fn PyCode_NewEmpty(filename: *const c_char,
                            funcname: *const c_char,
                            firstlineno: c_int) -> *mut PyCodeObject;

--- a/python3-sys/src/compile.rs
+++ b/python3-sys/src/compile.rs
@@ -63,9 +63,15 @@ pub const FUTURE_ANNOTATIONS      : &'static str = "annotations";
     #[cfg(Py_3_4)]
     pub fn PyCompile_OpcodeStackEffect(opcode: c_int,
                                        oparg: c_int) -> c_int;
+    #[cfg(Py_3_8)]
+    pub fn PyCompile_OpcodeStackEffectWithJump(opcode: c_int,
+                                               oparg: c_int,
+                                               jump: c_int) -> c_int;
 }
 
 pub const Py_single_input: c_int = 256;
 pub const Py_file_input: c_int = 257;
 pub const Py_eval_input: c_int = 258;
+#[cfg(Py_3_8)]
+pub const Py_func_type_input: c_int = 345;
 

--- a/python3-sys/src/dictobject.rs
+++ b/python3-sys/src/dictobject.rs
@@ -10,6 +10,9 @@ use object::*;
     pub static mut PyDictKeys_Type: PyTypeObject;
     pub static mut PyDictItems_Type: PyTypeObject;
     pub static mut PyDictValues_Type: PyTypeObject;
+    #[cfg(Py_3_8)] pub static mut PyDictRevIterKey_Type: PyTypeObject;
+    #[cfg(Py_3_8)] pub static mut PyDictRevIterValue_Type: PyTypeObject;
+    #[cfg(Py_3_8)] pub static mut PyDictRevIterItem_Type: PyTypeObject;
 }
 
 #[inline(always)]
@@ -24,17 +27,17 @@ pub unsafe fn PyDict_CheckExact(op : *mut PyObject) -> c_int {
 
 #[inline(always)]
 pub unsafe fn PyDictKeys_Check(op : *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &mut PyDictKeys_Type) as c_int
+    PyObject_TypeCheck(op, &mut PyDictKeys_Type)
 }
 
 #[inline(always)]
 pub unsafe fn PyDictItems_Check(op : *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &mut PyDictItems_Type) as c_int
+    PyObject_TypeCheck(op, &mut PyDictItems_Type)
 }
 
 #[inline(always)]
 pub unsafe fn PyDictValues_Check(op : *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &mut PyDictValues_Type) as c_int
+    PyObject_TypeCheck(op, &mut PyDictValues_Type)
 }
 
 #[inline(always)]

--- a/python3-sys/src/fileutils.rs
+++ b/python3-sys/src/fileutils.rs
@@ -1,6 +1,6 @@
 use libc::{c_char, size_t, wchar_t};
 
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(any(Py_3_5, not(Py_LIMITED_API)))]
 #[cfg_attr(windows, link(name="pythonXY"))]
 extern "C" {
     pub fn Py_DecodeLocale(arg: *const c_char, size: *mut size_t) -> *const wchar_t;

--- a/python3-sys/src/lib.rs
+++ b/python3-sys/src/lib.rs
@@ -77,7 +77,7 @@ pub use marshal::*;
 mod pyport;
 // mod pymacro; contains nothing of interest for Rust
 
-// mod pyatomic; contains nothing of interest for Rust
+// mod pyatomic; contains nothing of interest for Rust; moved to internal/pycore_atomic.h in 3.8
 
 // mod pymath; contains nothing of interest for Rust
 
@@ -125,6 +125,7 @@ mod warnings; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and
 mod weakrefobject; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod structseq; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 // mod namespaceobject; TODO
+// mod picklebufobject; TODO
 
 mod codecs; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod pyerrors; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
@@ -159,6 +160,7 @@ mod pystrtod; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and
 #[cfg(Py_3_5)]
 mod fileutils;
 // mod pyfpe; TODO probably not interesting for rust
+// mod tracemalloc; TODO probably not interesting for rust
 
 // Additional headers that are not exported by Python.h
 pub mod structmember; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5

--- a/python3-sys/src/moduleobject.rs
+++ b/python3-sys/src/moduleobject.rs
@@ -23,6 +23,7 @@ pub unsafe fn PyModule_CheckExact(op : *mut PyObject) -> c_int {
     pub fn PyModule_GetDict(arg1: *mut PyObject) -> *mut PyObject;
     pub fn PyModule_GetNameObject(arg1: *mut PyObject) -> *mut PyObject;
     pub fn PyModule_GetName(arg1: *mut PyObject) -> *const c_char;
+    #[deprecated(since="0.3.1", note="Deprecated since Python 3.2; use PyModule_GetFilenameObject() instead")]
     pub fn PyModule_GetFilename(arg1: *mut PyObject) -> *const c_char;
     pub fn PyModule_GetFilenameObject(arg1: *mut PyObject) -> *mut PyObject;
     pub fn PyModule_GetDef(arg1: *mut PyObject) -> *mut PyModuleDef;

--- a/python3-sys/src/objectabstract.rs
+++ b/python3-sys/src/objectabstract.rs
@@ -81,6 +81,7 @@ pub unsafe fn PyObject_CheckBuffer(o: *mut PyObject) -> c_int {
     (!tp_as_buffer.is_null() && (*tp_as_buffer).bf_getbuffer.is_some()) as c_int
 }
 
+// Python 3.8 moved these from Include/abstract.h to Include/cpython/abstract.h
 #[cfg(not(Py_LIMITED_API))]
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
     pub fn PyObject_GetBuffer(obj: *mut PyObject, view: *mut Py_buffer,
@@ -126,7 +127,10 @@ pub unsafe fn PyIter_Check(o: *mut PyObject) -> c_int {
 
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
     pub fn PyIter_Next(arg1: *mut PyObject) -> *mut PyObject;
-    
+    // Note: without Py_LIMITED_API, PyIter_Check is a macro instead
+    #[cfg(all(Py_3_8, Py_LIMITED_API))]
+    pub fn PyIter_Check(o: *mut PyObject) -> c_int;
+
     pub fn PyNumber_Check(o: *mut PyObject) -> c_int;
     pub fn PyNumber_Add(o1: *mut PyObject, o2: *mut PyObject)
      -> *mut PyObject;
@@ -170,6 +174,10 @@ pub unsafe fn PyIndex_Check(o: *mut PyObject) -> c_int {
 }
 
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
+    // Note: without Py_LIMITED_API, PyIndex_Check is a macro instead
+    #[cfg(all(Py_3_8, Py_LIMITED_API))]
+    pub fn PyIndex_Check(o: *mut PyObject) -> c_int;
+
     pub fn PyNumber_Index(o: *mut PyObject) -> *mut PyObject;
     pub fn PyNumber_AsSsize_t(o: *mut PyObject, exc: *mut PyObject)
      -> Py_ssize_t;

--- a/python3-sys/src/pyerrors.rs
+++ b/python3-sys/src/pyerrors.rs
@@ -52,7 +52,16 @@ pub unsafe fn PyExceptionInstance_Class(x: *mut PyObject) -> *mut PyObject {
     (*x).ob_type as *mut PyObject
 }
 
+#[cfg(all(not(Py_3_8), not(Py_LIMITED_API)))]
+#[inline]
+pub unsafe fn PyExceptionClass_Name(x: *mut PyObject) -> *const c_char {
+    (*(*x).ob_type).tp_name
+}
+
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
+    #[cfg(Py_3_8)]
+    pub fn PyExceptionClass_Name(o: *mut PyObject) -> *const c_char;
+
     pub static mut PyExc_BaseException: *mut PyObject;
     pub static mut PyExc_Exception: *mut PyObject;
     #[cfg(Py_3_5)] pub static mut PyExc_StopAsyncIteration: *mut PyObject;

--- a/python3-sys/src/pystate.rs
+++ b/python3-sys/src/pystate.rs
@@ -12,6 +12,8 @@ pub enum PyThreadState { }
     pub fn PyInterpreterState_New() -> *mut PyInterpreterState;
     pub fn PyInterpreterState_Clear(arg1: *mut PyInterpreterState) -> ();
     pub fn PyInterpreterState_Delete(arg1: *mut PyInterpreterState) -> ();
+    #[cfg(Py_3_8)]
+    pub fn PyInterpreterState_GetDict(arg1: *mut PyInterpreterState) -> *mut PyObject;
     #[cfg(Py_3_7)]
     pub fn PyInterpreterState_GetID(arg1: *mut PyInterpreterState) -> i64;
     pub fn PyState_FindModule(arg1: *mut PyModuleDef) -> *mut PyObject;

--- a/python3-sys/src/pythonrun.rs
+++ b/python3-sys/src/pythonrun.rs
@@ -28,7 +28,8 @@ use pyarena::PyArena;
 #[derive(Copy, Clone)]
 #[cfg(not(Py_LIMITED_API))]
 pub struct PyCompilerFlags {
-    pub cf_flags : c_int
+    pub cf_flags : c_int,
+    #[cfg(Py_3_8)] pub cf_feature_version : c_int
 }
 
 #[cfg(not(Py_LIMITED_API))]
@@ -185,6 +186,9 @@ pub unsafe fn Py_CompileStringFlags(string: *const c_char, p: *const c_char, s: 
      -> c_int;
     pub fn Py_Exit(arg1: c_int) -> ();
     pub fn Py_Main(argc: c_int, argv: *mut *mut wchar_t)
+     -> c_int;
+    #[cfg(Py_3_8)]
+    pub fn Py_BytesMain(argc: c_int, argv: *mut *mut c_char)
      -> c_int;
     pub fn Py_GetProgramFullPath() -> *mut wchar_t;
     pub fn Py_GetPrefix() -> *mut wchar_t;


### PR DESCRIPTION
This time around the diff between the Python 3.7.0 and Python 3.8.0 headers was non-trivial; because several parts of the non-limited API were moved around (mostly to the new internal `Include/cpython/*.h` headers).
So it's quite possible that I missed some relevant changes.

It turned out that rust-cpython mostly already works without these changes (enough that all our tests except for `check_symbols.py` pass on Python 3.8 without this PR!).
`PyCodeObject` is obviously broken without this PR, but it's unused in `rust-cpython`.
`PyTypeObject` is a bit more tricky, but in the usual case we're saved because we don't set `_Py_TPFLAGS_HAVE_VECTORCALL`, so an out-of-bounds read should not happen. Only in the rare case when compiling against a Python interpreter using the `COUNT_ALLOCS` mode it's important to have exactly the correct `PyTypeObject` definition.