### PR TITLE
Define inittab entities

### DIFF
--- a/python3-sys/src/import.rs
+++ b/python3-sys/src/import.rs
@@ -73,6 +73,14 @@ pub unsafe fn PyImport_ImportModuleEx(name: *const c_char,
 #[repr(C)]
 #[derive(Copy, Clone)]
 #[cfg(not(Py_LIMITED_API))]
+pub struct _inittab {
+    pub name: *mut c_char,
+    pub initfunc: Option<unsafe extern "C" fn()>,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[cfg(not(Py_LIMITED_API))]
 pub struct _frozen {
     pub name: *const c_char,
     pub code: *const c_uchar,
@@ -83,4 +91,7 @@ pub struct _frozen {
 #[cfg_attr(windows, link(name="pythonXY"))]
 extern "C" {
     pub static mut PyImport_FrozenModules: *const _frozen;
+    pub static mut PyImport_Inittab: *mut _inittab;
+
+    pub fn PyImport_ExtendInittab(newtab: *const _inittab) -> c_int;
 }


### PR DESCRIPTION
The struct and function are documented at
https://docs.python.org/3/c-api/import.html#c._inittab
and defined in source code (in CPython master) at
https://github.com/python/cpython/blob/51edf8aaa2e17626f9690ed29d25945fc03016b9/Include/cpython/import.h#L30.

It is unclear whether PyImport_Inittab is part of the official
API, as it isn't clearly documented. But the static has been
shipping for years and is still in CPython master. I need to
use this variable in PyOxidizer in order to modify the set
of extensions at run-time. Putting it behind Py_LIMITED_API
should be safe.
