### PR TITLE
Explicitly pass doc argument to py_method_def!

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -149,7 +149,7 @@ macro_rules! py_fn_impl {
         }
         unsafe {
             $crate::_detail::py_fn_impl($py,
-                py_method_def!(_cpython__function__stringify!($f), 0, wrap))
+                py_method_def!(_cpython__function__stringify!($f), 0, wrap, ""))
         }
     }};
     // Form 2: inline function definition


### PR DESCRIPTION
Without this, attempting to use py_fn! in an external crate
results in a compile error:

```
error: cannot find macro `py_method_def` in this scope
   --> pyembed/src/importer.rs:631:9
    |
631 | /         py_fn!(
632 | |             py,
633 | |             module_setup(
634 | |                 m: PyModule,
...   |
638 | |             )
639 | |         ),
    | |_________^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

Why this occurs, I'm not sure (I don't fully grok macros). But passing
an explicit value to the `doc` argument makes it work.