### PR TITLE
improve PythonObjectDowncastError TypeErrors

### DIFF
--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -69,7 +69,7 @@ pub fn parse_args(
                     fname.unwrap_or("function"),
                     if fname.is_some() { "()" } else { "" },
                     params.len(),
-                    if params.len() == 1 { "s" } else { "" },
+                    if params.len() != 1 { "s" } else { "" },
                     nargs + nkeywords
                 )));
     }

--- a/src/objects/exc.rs
+++ b/src/objects/exc.rs
@@ -42,7 +42,11 @@ macro_rules! exc_type(
                     if ffi::PyObject_TypeCheck(obj.as_ptr(), ffi::$exc_name as *mut ffi::PyTypeObject) != 0 {
                         Ok(PythonObject::unchecked_downcast_from(obj))
                     } else {
-                        Err(PythonObjectDowncastError(py))
+                        Err(PythonObjectDowncastError::new(
+                            py,
+                            stringify!($name),
+                            obj.get_type(py),
+                        ))
                     }
                 }
             }
@@ -55,7 +59,11 @@ macro_rules! exc_type(
                     if ffi::PyObject_TypeCheck(obj.as_ptr(), ffi::$exc_name as *mut ffi::PyTypeObject) != 0 {
                         Ok(PythonObject::unchecked_downcast_borrow_from(obj))
                     } else {
-                        Err(PythonObjectDowncastError(py))
+                        Err(PythonObjectDowncastError::new(
+                            py,
+                            stringify!($name),
+                            obj.get_type(py),
+                        ))
                     }
                 }
             }
@@ -152,4 +160,3 @@ impl UnicodeDecodeError {
         UnicodeDecodeError::new(py, cstr!("utf-8"), input, pos .. pos+1, cstr!("invalid utf-8"))
     }
 }
-

--- a/src/objects/iterator.rs
+++ b/src/objects/iterator.rs
@@ -37,7 +37,7 @@ impl <'p> PyIterator<'p> {
         if unsafe { ffi::PyIter_Check(obj.as_ptr()) != 0 } {
             Ok(PyIterator { py: py, iter: obj })
         } else {
-            Err(PythonObjectDowncastError(py))
+            Err(PythonObjectDowncastError::new(py, "PyIterator", obj.get_type(py)))
         }
     }
 

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -82,7 +82,11 @@ macro_rules! pyobject_newtype(
                     if ::ffi::$checkfunction(obj.as_ptr()) != 0 {
                         Ok($name(obj))
                     } else {
-                        Err(::python::PythonObjectDowncastError(py))
+                        Err(::python::PythonObjectDowncastError::new(
+                            py,
+                            _cpython__objects__stringify!($name),
+                            obj.get_type(py)
+                        ))
                     }
                 }
             }
@@ -93,7 +97,11 @@ macro_rules! pyobject_newtype(
                     if ::ffi::$checkfunction(obj.as_ptr()) != 0 {
                         Ok(::std::mem::transmute(obj))
                     } else {
-                        Err(::python::PythonObjectDowncastError(py))
+                        Err(::python::PythonObjectDowncastError::new(
+                            py,
+                            _cpython__objects__stringify!($name),
+                            obj.get_type(py)
+                        ))
                     }
                 }
             }
@@ -123,6 +131,14 @@ macro_rules! extract(
         }
     }
 );
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _cpython__objects__stringify {
+    ($($inner:tt)*) => {
+        stringify! { $($inner)* }
+    }
+}
 
 mod object;
 mod typeobject;

--- a/src/objects/string.rs
+++ b/src/objects/string.rs
@@ -61,7 +61,7 @@ impl ::python::PythonObjectWithCheckedDowncast for PyString {
         if is_base_string(&obj) {
             Ok(PyString(obj))
         } else {
-            Err(PythonObjectDowncastError(py))
+            Err(PythonObjectDowncastError::new(py, "PyString", obj.get_type(py)))
         }
     }
 
@@ -71,7 +71,7 @@ impl ::python::PythonObjectWithCheckedDowncast for PyString {
             if is_base_string(obj) {
                 Ok(::std::mem::transmute(obj))
             } else {
-                Err(::python::PythonObjectDowncastError(py))
+                Err(::python::PythonObjectDowncastError::new(py, "PyString", obj.get_type(py)))
             }
         }
     }

--- a/src/py_class/py_class_impl.py
+++ b/src/py_class/py_class_impl.py
@@ -88,7 +88,11 @@ base_case = '''
                 if py.get_type::<$class>().is_instance(py, &obj) {
                     Ok($class { _unsafe_inner: obj })
                 } else {
-                    Err($crate::PythonObjectDowncastError(py))
+                    Err($crate::PythonObjectDowncastError::new(
+                        py,
+                        _cpython__py_class__py_class_impl__stringify!($class),
+                        obj.get_type(py),
+                    ))
                 }
             }
 
@@ -97,7 +101,11 @@ base_case = '''
                 if py.get_type::<$class>().is_instance(py, obj) {
                     unsafe { Ok(::std::mem::transmute(obj)) }
                 } else {
-                    Err($crate::PythonObjectDowncastError(py))
+                    Err($crate::PythonObjectDowncastError::new(
+                        py,
+                        _cpython__py_class__py_class_impl__stringify!($class),
+                        obj.get_type(py),
+                    ))
                 }
             }
         }

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -80,7 +80,11 @@ macro_rules! py_class_impl {
                 if py.get_type::<$class>().is_instance(py, &obj) {
                     Ok($class { _unsafe_inner: obj })
                 } else {
-                    Err($crate::PythonObjectDowncastError(py))
+                    Err($crate::PythonObjectDowncastError::new(
+                        py,
+                        _cpython__py_class__py_class_impl__stringify!($class),
+                        obj.get_type(py),
+                    ))
                 }
             }
 
@@ -89,7 +93,11 @@ macro_rules! py_class_impl {
                 if py.get_type::<$class>().is_instance(py, obj) {
                     unsafe { Ok(::std::mem::transmute(obj)) }
                 } else {
-                    Err($crate::PythonObjectDowncastError(py))
+                    Err($crate::PythonObjectDowncastError::new(
+                        py,
+                        _cpython__py_class__py_class_impl__stringify!($class),
+                        obj.get_type(py),
+                    ))
                 }
             }
         }

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -80,7 +80,11 @@ macro_rules! py_class_impl {
                 if py.get_type::<$class>().is_instance(py, &obj) {
                     Ok($class { _unsafe_inner: obj })
                 } else {
-                    Err($crate::PythonObjectDowncastError(py))
+                    Err($crate::PythonObjectDowncastError::new(
+                        py,
+                        _cpython__py_class__py_class_impl__stringify!($class),
+                        obj.get_type(py),
+                    ))
                 }
             }
 
@@ -89,7 +93,11 @@ macro_rules! py_class_impl {
                 if py.get_type::<$class>().is_instance(py, obj) {
                     unsafe { Ok(::std::mem::transmute(obj)) }
                 } else {
-                    Err($crate::PythonObjectDowncastError(py))
+                    Err($crate::PythonObjectDowncastError::new(
+                        py,
+                        _cpython__py_class__py_class_impl__stringify!($class),
+                        obj.get_type(py),
+                    ))
                 }
             }
         }

--- a/src/python.rs
+++ b/src/python.rs
@@ -56,7 +56,26 @@ pub trait PythonObject : ::conversion::ToPyObject + Send + Sized + 'static {
 }
 
 // Marker type that indicates an error while downcasting
-pub struct PythonObjectDowncastError<'p>(pub Python<'p>);
+pub struct PythonObjectDowncastError<'p> {
+    pub(crate) py: Python<'p>,
+    pub(crate) expected_type_name: String,
+    pub(crate) received_type: PyType,
+}
+
+impl<'p> PythonObjectDowncastError<'p> {
+    pub fn new(
+        py: Python<'p>,
+        expected_type_name: impl Into<String>,
+        received_type: PyType) -> Self
+    {
+        let expected_type_name = expected_type_name.into();
+        PythonObjectDowncastError {
+            py,
+            expected_type_name,
+            received_type,
+        }
+    }
+}
 
 /// Trait implemented by Python object types that allow a checked downcast.
 pub trait PythonObjectWithCheckedDowncast : PythonObject {


### PR DESCRIPTION
When TypeErrors are generated from PythonObjectDowncastErrors, include
the type that the downcast was targetted at, and the type of the object
that was being targetted.

This results in errors like:

    TypeError: Expected type that converts to PyString but received int