### PR TITLE
Implement reference extraction for slot functions and optional reference extraction

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -217,12 +217,10 @@ impl PyErr {
     /// The error is cleared from the Python interpreter.
     /// If no error is set, returns a `SystemError`.
     pub fn fetch(py: Python) -> PyErr {
-        // TODO: Switch to std::mem::MaybeUninit once available.
-        #[allow(deprecated)]
+        let mut ptype: *mut ffi::PyObject = ptr::null_mut();
+        let mut pvalue: *mut ffi::PyObject = ptr::null_mut();
+        let mut ptraceback: *mut ffi::PyObject = ptr::null_mut();
         unsafe {
-            let mut ptype: *mut ffi::PyObject = std::mem::uninitialized();
-            let mut pvalue: *mut ffi::PyObject = std::mem::uninitialized();
-            let mut ptraceback: *mut ffi::PyObject = std::mem::uninitialized();
             ffi::PyErr_Fetch(&mut ptype, &mut pvalue, &mut ptraceback);
             PyErr::new_from_ffi_tuple(py, ptype, pvalue, ptraceback)
         }

--- a/src/objects/string.rs
+++ b/src/objects/string.rs
@@ -284,10 +284,8 @@ impl PyString {
     fn data_impl(&self, py: Python) -> PyStringData {
         // TODO: return the original representation instead
         // of forcing the UTF-8 representation to be created.
-        // TODO: Switch to std::mem::MaybeUninit once available.
-        #[allow(deprecated)]
+        let mut size: ffi::Py_ssize_t = 0;
         unsafe {
-            let mut size: ffi::Py_ssize_t = mem::uninitialized();
             let data = ffi::PyUnicode_AsUTF8AndSize(self.as_ptr(), &mut size) as *const u8;
             if data.is_null() {
                 PyErr::fetch(py).print(py);

--- a/tests/test_function.rs
+++ b/tests/test_function.rs
@@ -99,6 +99,38 @@ fn inline_two_args() {
     );
 }
 
+#[test]
+fn opt_args() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let obj = py_fn!(py, f(a: Option<&str>, b: &str, c: Option<&str> = None) -> PyResult<String> {
+        drop(py);
+        Ok(format!("a: {:?}  b: {:?}  c: {:?}", a, b, c))
+    });
+
+    assert_eq!(
+        obj.call(py, (py.None(), "string"), None)
+            .unwrap()
+            .extract::<String>(py)
+            .unwrap(),
+        r#"a: None  b: "string"  c: None"#,
+    );
+    assert_eq!(
+        obj.call(py, ("double", "string", py.None()), None)
+            .unwrap()
+            .extract::<String>(py)
+            .unwrap(),
+        r#"a: Some("double")  b: "string"  c: None"#,
+    );
+    assert_eq!(
+        obj.call(py, ("triple", "string", "args"), None)
+            .unwrap()
+            .extract::<String>(py)
+            .unwrap(),
+        r#"a: Some("triple")  b: "string"  c: Some("args")"#,
+    );
+}
+
 /* TODO: reimplement flexible sig support
 #[test]
 fn flexible_sig() {


### PR DESCRIPTION
This allows slot implementations with a single parameter (in particular,
`__compare__`, `__getitem__`, `__delitem__`, and in-place operators like `__iadd__`),
as well as `__richcmp__` to work with reference types (types that implement
RefFromPyObject) as well as full types (types that implement FromPyObject).

Additionally, optional references are included.  This is an improvement over
normal methods, so this is extended to normal methods, too.

The syntax is the same as for methods, e.g.

    def __contains__(&self, key: &KeyType) -> PyResult<bool>

will generate a method where the key will be borrowed from the PyObject,
rather than copied.

Similarly for optional references:

    def __contains__(&self, key: Option<&KeyType>) -> PyResult<bool>

will be the same, except that the key will be `None` if the user provided
Python `None`.

The `__setitem__` method only supports reference extraction for the first
parameter (the key).  The value still needs to be a fully extracted type.

Binary arithmetic operators, like `__add__`, are not included.