### PR TITLE
Implement property support

### DIFF
--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -38,11 +38,7 @@ pub struct ParamDescription<'a> {
 impl<'a> ParamDescription<'a> {
     /// Name, with leading `r#` stripped.
     pub fn name(&self) -> &str {
-        if self.name.starts_with("r#") {
-            &self.name[2..]
-        } else {
-            self.name
-        }
+        crate::strip_raw!(self.name)
     }
 }
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -217,12 +217,10 @@ impl PyErr {
     /// The error is cleared from the Python interpreter.
     /// If no error is set, returns a `SystemError`.
     pub fn fetch(py: Python) -> PyErr {
-        // TODO: Switch to std::mem::MaybeUninit once available.
-        #[allow(deprecated)]
+        let mut ptype: *mut ffi::PyObject = ptr::null_mut();
+        let mut pvalue: *mut ffi::PyObject = ptr::null_mut();
+        let mut ptraceback: *mut ffi::PyObject = ptr::null_mut();
         unsafe {
-            let mut ptype: *mut ffi::PyObject = std::mem::uninitialized();
-            let mut pvalue: *mut ffi::PyObject = std::mem::uninitialized();
-            let mut ptraceback: *mut ffi::PyObject = std::mem::uninitialized();
             ffi::PyErr_Fetch(&mut ptype, &mut pvalue, &mut ptraceback);
             PyErr::new_from_ffi_tuple(py, ptype, pvalue, ptraceback)
         }

--- a/src/function.rs
+++ b/src/function.rs
@@ -45,10 +45,7 @@ macro_rules! py_method_def {
                     | $flags,
                 ml_doc: 0 as *const $crate::_detail::libc::c_char,
             };
-        METHOD_DEF.ml_name = concat!($name, "\0").as_ptr() as *const _;
-        if $name.starts_with("r#") {
-            METHOD_DEF.ml_name = METHOD_DEF.ml_name.add(2);
-        }
+        METHOD_DEF.ml_name = $crate::strip_raw!(concat!($name, "\0")).as_ptr() as *const _;
         if !$doc.is_empty() {
             METHOD_DEF.ml_doc = concat!($doc, "\0").as_ptr() as *const _;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,3 +393,17 @@ pub unsafe fn py_module_initializer_impl(
     mem::forget(guard);
     ret
 }
+
+// Strip 'r#' prefix from stringified raw identifiers.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! strip_raw {
+    ($s:expr) => {{
+        let s = $s;
+        if s.starts_with("r#") {
+            &s[2..]
+        } else {
+            s
+        }
+    }};
+}

--- a/src/objects/string.rs
+++ b/src/objects/string.rs
@@ -284,10 +284,8 @@ impl PyString {
     fn data_impl(&self, py: Python) -> PyStringData {
         // TODO: return the original representation instead
         // of forcing the UTF-8 representation to be created.
-        // TODO: Switch to std::mem::MaybeUninit once available.
-        #[allow(deprecated)]
+        let mut size: ffi::Py_ssize_t = 0;
         unsafe {
-            let mut size: ffi::Py_ssize_t = mem::uninitialized();
             let data = ffi::PyUnicode_AsUTF8AndSize(self.as_ptr(), &mut size) as *const u8;
             if data.is_null() {
                 PyErr::fetch(py).print(py);

--- a/src/py_class/members.rs
+++ b/src/py_class/members.rs
@@ -63,12 +63,7 @@ macro_rules! py_class_init_members {
             let descriptor = unsafe {
                 $crate::py_class::members::TypeMember::<$class>::into_descriptor(init, $py, &mut $type_object)
             }?;
-            let name = stringify!($name);
-            let name = if name.starts_with("r#") {
-                &name[2..]
-            } else {
-                name
-            };
+            let name = $crate::strip_raw!(stringify!($name));
             dict.set_item($py, name, descriptor)?;
         })*
         unsafe {

--- a/src/py_class/py_class.rs
+++ b/src/py_class/py_class.rs
@@ -166,6 +166,24 @@ Declares a static method callable from Python.
 * For details on `parameter-list`, see the documentation of `py_argparse!()`.
 * The return type must be `PyResult<T>` for some `T` that implements `ToPyObject`.
 
+## Properties
+`@property def property_name(&self) -> PyResult<...> { ... }`
+
+`@property_name.setter def set_method_name(&self, value: Option<impl FromPyObject>) -> PyResult<()> { ... }`
+
+Declares a property (attribute with code for getting and optionally setting) accessible from Python.
+
+* The setter is optional.  If omitted, the attribute will be read-only.
+* Unlike Python, the setter method name must be different from the property name.
+  The setter method name is used to call the setter from Rust.
+* If value is `None` then the property is being deleted.
+* The value type can be any type that implements `FromPyObject`, or a reference or
+  optional reference to any type that implements `RefFromPyObject`.  In the latter
+  case, the type of the value is `Option<Option<&impl RefFromPyObject>>`, where
+  `None` means the property is being deleted, `Some(None)` means the property is
+  being set to Python `None`, and `Some(Some(value))` means the property is being
+  set to the given value.
+
 ## __new__
 `def __new__(cls, parameter-list) -> PyResult<...> { ... }`
 
@@ -448,6 +466,7 @@ macro_rules! py_class {
             }
             /* impls: */ { /* impl body */ }
             /* members: */ { /* ident = expr; */ }
+            /* props: */ { [ /* getters */ ] [ /* setters */ ] }
         }
     );
     (pub class $class:ident |$py: ident| { $( $body:tt )* }) => (
@@ -477,6 +496,7 @@ macro_rules! py_class {
             }
             /* impls: */ { /* impl body */ }
             /* members: */ { /* ident = expr; */ }
+            /* props: */ { [ /* getters */ ] [ /* setters */ ] }
         }
     );
 }

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -39,7 +39,7 @@ macro_rules! py_class_impl {
             $gc:tt,
             /* data: */ [ $( { $data_offset:expr, $data_name:ident, $data_ty:ty, $init_expr:expr, $init_ty:ty } )* ]
         }
-        $slots:tt { $( $imp:item )* } $members:tt
+        $slots:tt { $( $imp:item )* } $members:tt $props:tt
     } => {
         $crate::py_coerce_item! {
             $($class_visibility)* struct $class { _unsafe_inner: $crate::PyObject }
@@ -182,7 +182,7 @@ macro_rules! py_class_impl {
                     }
 
                     fn init($py: $crate::Python, module_name: Option<&str>) -> $crate::PyResult<$crate::PyType> {
-                        $crate::py_class_type_object_dynamic_init!($class, $py, TYPE_OBJECT, module_name, $slots);
+                        $crate::py_class_type_object_dynamic_init!($class, $py, TYPE_OBJECT, module_name, $slots $props);
                         $crate::py_class_init_members!($class, $py, TYPE_OBJECT, $members);
                         unsafe {
                             if $crate::_detail::ffi::PyType_Ready(&mut TYPE_OBJECT) == 0 {
@@ -208,7 +208,7 @@ macro_rules! py_class_impl {
         }
         $slots:tt
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py
@@ -243,7 +243,7 @@ macro_rules! py_class_impl {
                 }
             }
         }
-        $members
+        $members $props
     }};
     { { @shared data $data_name:ident : $data_type:ty; $($tail:tt)* }
         $class:ident $py:ident
@@ -256,7 +256,7 @@ macro_rules! py_class_impl {
         }
         $slots:tt
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py
@@ -292,7 +292,7 @@ macro_rules! py_class_impl {
                 }
             }
         }
-        $members
+        $members $props
     }};
     { { def __traverse__(&$slf:tt, $visit:ident) $body:block $($tail:tt)* }
         $class:ident $py:ident
@@ -308,7 +308,7 @@ macro_rules! py_class_impl {
         }
         $slots:tt
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py
@@ -335,7 +335,7 @@ macro_rules! py_class_impl {
                 }
             }
         }
-        $members
+        $members $props
     }};
     { { def __clear__ (&$slf:ident) $body:block $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -344,7 +344,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -363,7 +363,7 @@ macro_rules! py_class_impl {
                 }
             }
         }
-        $members
+        $members $props
     }};
     { { def __abs__(&$slf:ident) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -373,7 +373,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -389,7 +389,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __abs__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __abs__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -403,7 +403,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -419,7 +419,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __add__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __add__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -445,7 +445,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -461,7 +461,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __and__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __and__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -479,7 +479,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -495,7 +495,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __bool__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __bool__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -508,7 +508,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -523,7 +523,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __call__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
     { {  def __call__ (&$slf:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -532,7 +532,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -550,7 +550,7 @@ macro_rules! py_class_impl {
                 [] ($($p)+,)
             }
         }
-        $members
+        $members $props
     }};
 
     { { def __cmp__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -572,7 +572,7 @@ macro_rules! py_class_impl {
             $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -588,7 +588,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : Option<&$item_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __contains__(&$slf:ident, $item:ident : &$item_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -598,7 +598,7 @@ macro_rules! py_class_impl {
             $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -614,7 +614,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : &$item_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __contains__(&$slf:ident, $item:ident : $item_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -624,7 +624,7 @@ macro_rules! py_class_impl {
             $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -640,7 +640,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : $item_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __contains__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -668,7 +668,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -683,7 +683,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __delitem__(&$slf:ident, $key:ident : &$key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -695,7 +695,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -710,7 +710,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __delitem__(&$slf:ident, $key:ident : $key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -722,7 +722,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -737,7 +737,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __delitem__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -792,7 +792,7 @@ macro_rules! py_class_impl {
             $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -812,7 +812,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __getitem__(&$slf:ident, $key:ident : &$key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -823,7 +823,7 @@ macro_rules! py_class_impl {
             $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -843,7 +843,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __getitem__(&$slf:ident, $key:ident : $key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -854,7 +854,7 @@ macro_rules! py_class_impl {
             $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -874,7 +874,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __getitem__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -891,7 +891,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -906,7 +906,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __hash__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __hash__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -920,7 +920,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -936,7 +936,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __iadd__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -946,7 +946,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -962,7 +962,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __iadd__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -972,7 +972,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -988,7 +988,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __iadd__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1002,7 +1002,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1018,7 +1018,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __iand__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1028,7 +1028,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1044,7 +1044,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __iand__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1054,7 +1054,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1070,7 +1070,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __iand__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1088,7 +1088,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1104,7 +1104,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ifloordiv__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1114,7 +1114,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1130,7 +1130,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ifloordiv__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1140,7 +1140,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1156,7 +1156,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __ifloordiv__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1170,7 +1170,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1186,7 +1186,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ilshift__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1196,7 +1196,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1212,7 +1212,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ilshift__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1222,7 +1222,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1238,7 +1238,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __ilshift__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1252,7 +1252,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1268,7 +1268,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imatmul__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1278,7 +1278,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1294,7 +1294,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imatmul__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1304,7 +1304,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1320,7 +1320,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __imatmul__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1334,7 +1334,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1350,7 +1350,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imod__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1360,7 +1360,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1376,7 +1376,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imod__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1386,7 +1386,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1402,7 +1402,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __imod__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1416,7 +1416,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1432,7 +1432,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imul__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1442,7 +1442,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1458,7 +1458,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imul__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1468,7 +1468,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1484,7 +1484,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __imul__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1514,7 +1514,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1530,7 +1530,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __invert__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __invert__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1544,7 +1544,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1560,7 +1560,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ior__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1570,7 +1570,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1586,7 +1586,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ior__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1596,7 +1596,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1612,7 +1612,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __ior__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1630,7 +1630,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1646,7 +1646,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __irshift__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1656,7 +1656,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1672,7 +1672,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __irshift__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1682,7 +1682,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1698,7 +1698,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __irshift__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1712,7 +1712,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1728,7 +1728,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __isub__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1738,7 +1738,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1754,7 +1754,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __isub__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1764,7 +1764,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1780,7 +1780,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __isub__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1793,7 +1793,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1808,7 +1808,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iter__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __iter__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1822,7 +1822,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1838,7 +1838,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __itruediv__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1848,7 +1848,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1864,7 +1864,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __itruediv__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1874,7 +1874,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1890,7 +1890,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __itruediv__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1904,7 +1904,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1920,7 +1920,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ixor__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1930,7 +1930,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1946,7 +1946,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ixor__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1956,7 +1956,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1972,7 +1972,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __ixor__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1991,7 +1991,7 @@ macro_rules! py_class_impl {
             $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2011,7 +2011,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __len__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __len__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2029,7 +2029,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2045,7 +2045,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __lshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __lshift__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2071,7 +2071,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2087,7 +2087,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __mul__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __mul__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2105,7 +2105,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2121,7 +2121,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __neg__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __neg__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2134,7 +2134,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2149,7 +2149,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py,__new__($cls: &$crate::PyType,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
     { {  def __new__ ($cls:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2158,7 +2158,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2176,7 +2176,7 @@ macro_rules! py_class_impl {
                 [] ($($p)+,)
             }
         }
-        $members
+        $members $props
     }};
     { { def __next__(&$slf:ident) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2185,7 +2185,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2200,7 +2200,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __next__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __next__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2218,7 +2218,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2234,7 +2234,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __or__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __or__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2248,7 +2248,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2264,7 +2264,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __pos__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __pos__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2297,7 +2297,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2312,7 +2312,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __repr__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __repr__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2329,7 +2329,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2344,7 +2344,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} } { $op : $op_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __richcmp__(&$slf:ident, $other:ident : &$other_name:ty, $op:ident : $op_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2353,7 +2353,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2368,7 +2368,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} } { $op : $op_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __richcmp__(&$slf:ident, $other:ident : $other_name:ty, $op:ident : $op_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2377,7 +2377,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2392,7 +2392,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} } { $op : $op_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __richcmp__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2438,7 +2438,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2454,7 +2454,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __rshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __rshift__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2490,7 +2490,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2505,7 +2505,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} } { $value : $value_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __setitem__(&$slf:ident, $key:ident : &$key_name:ty, $value:ident : $value_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2517,7 +2517,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2532,7 +2532,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} } { $value : $value_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __setitem__(&$slf:ident, $key:ident : $key_name:ty, $value:ident : $value_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2544,7 +2544,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2559,7 +2559,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} } { $value : $value_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __setitem__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2572,7 +2572,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2587,7 +2587,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __str__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __str__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2601,7 +2601,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2617,7 +2617,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __sub__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __sub__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2639,7 +2639,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2655,7 +2655,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __xor__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __xor__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2664,7 +2664,7 @@ macro_rules! py_class_impl {
     { { $(#[doc=$doc:expr])* def $name:ident (&$slf:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots
@@ -2675,12 +2675,12 @@ macro_rules! py_class_impl {
         /* members: */ {
             $( $member_name = $member_expr; )*
             $name = $crate::py_class_instance_method!{$py, $class::$name, { concat!($($doc, "\n"),*) } []};
-        }
+        } $props
     }};
     { { $(#[doc=$doc:expr])* def $name:ident (&$slf:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots
@@ -2694,12 +2694,12 @@ macro_rules! py_class_impl {
         /* members: */ {
             $( $member_name = $member_expr; )*
             $name = $crate::py_argparse_parse_plist_impl!{py_class_instance_method {$py, $class::$name, { concat!($($doc, "\n"),*) }} [] ($($p)+,)};
-        }
+        } $props
     }};
     { { $(#[doc=$doc:expr])*@classmethod def $name:ident ($cls:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots
@@ -2710,12 +2710,12 @@ macro_rules! py_class_impl {
         /* members: */ {
             $( $member_name = $member_expr; )*
             $name = $crate::py_class_class_method!{$py, $class::$name, { concat!($($doc, "\n"),*) } []};
-        }
+        } $props
     }};
     { { $(#[doc=$doc:expr])*@classmethod def $name:ident ($cls:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots
@@ -2729,12 +2729,12 @@ macro_rules! py_class_impl {
         /* members: */ {
             $( $member_name = $member_expr; )*
             $name = $crate::py_argparse_parse_plist_impl!{py_class_class_method {$py, $class::$name, { concat!($($doc, "\n"),*) }} [] ($($p)+,)};
-        }
+        } $props
     }};
     { { $(#[doc=$doc:expr])* @staticmethod def $name:ident ($($p:tt)*) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots
@@ -2755,17 +2755,105 @@ macro_rules! py_class_impl {
                 ($($p)*)
             }
             ;
-        }
+        } $props
     }};
     { { static $name:ident = $init:expr; $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt $impls:tt
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots $impls
         /* members: */ {
             $( $member_name = $member_expr; )*
             $name = $init;
+        } $props
+    }};
+    { { $(#[doc=$doc:expr])* @property def $name:ident(&$slf:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+        $class:ident $py:ident $info:tt $slots:tt
+        { $( $imp:item )* }
+        $members:tt
+        { [ $( $prop_doc:tt $prop_getter_name:ident: $prop_type:ty, )* ]
+            [ $( $prop_setter_name:ident : $prop_setter_value_type:tt => $prop_setter_setter:ident, )* ] }
+    } => { $crate::py_class_impl! {
+        { $($tail)* }
+        $class $py $info $slots
+        /* impl: */ {
+            $($imp)*
+            $crate::py_class_impl_item! { $class, $py, $name(&$slf,) $res_type; { $($body)* } [] }
+        }
+        $members
+        /* props: */ {
+            [ $( $prop_doc $prop_getter_name: $prop_type, )*
+                { concat!($($doc, "\n"),*) } $name: $res_type,
+            ]
+            [ $( $prop_setter_name : $prop_setter_value_type => $prop_setter_setter, )*
+            ]
+        }
+    }};
+    { { @$name:ident.setter def $setter_name:ident(&$slf:ident, $value:ident : Option<Option<&$value_type:ty>> ) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+        $class:ident $py:ident $info:tt $slots:tt
+        { $( $imp:item )* }
+        $members:tt
+        { [ $( $prop_doc:tt $prop_getter_name:ident: $prop_type:ty, )* ]
+            [ $( $prop_setter_name:ident : $prop_setter_value_type:tt => $prop_setter_setter:ident, )* ] }
+    } => { $crate::py_class_impl! {
+        { $($tail)* }
+        $class $py $info $slots
+        /* impl: */ {
+            $($imp)*
+            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<Option<&$value_type>> = {} }] }
+        }
+        $members
+        /* props: */ {
+            [ $( $prop_doc $prop_getter_name: $prop_type, )*
+            ]
+            [ $( $prop_setter_name : $prop_setter_value_type => $prop_setter_setter, )*
+                $name : [ Option<&$value_type> ] => $setter_name,
+            ]
+        }
+    }};
+    { { @$name:ident.setter def $setter_name:ident(&$slf:ident, $value:ident : Option<&$value_type:ty> ) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+        $class:ident $py:ident $info:tt $slots:tt
+        { $( $imp:item )* }
+        $members:tt
+        { [ $( $prop_doc:tt $prop_getter_name:ident: $prop_type:ty, )* ]
+            [ $( $prop_setter_name:ident : $prop_setter_value_type:tt => $prop_setter_setter:ident, )* ] }
+    } => { $crate::py_class_impl! {
+        { $($tail)* }
+        $class $py $info $slots
+        /* impl: */ {
+            $($imp)*
+            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<&$value_type> = {} }] }
+        }
+        $members
+        /* props: */ {
+            [ $( $prop_doc $prop_getter_name: $prop_type, )*
+            ]
+            [ $( $prop_setter_name : $prop_setter_value_type => $prop_setter_setter, )*
+                $name : [ &$value_type ] => $setter_name,
+            ]
+        }
+    }};
+    { { @$name:ident.setter def $setter_name:ident(&$slf:ident, $value:ident : Option<$value_type:ty> ) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+        $class:ident $py:ident $info:tt $slots:tt
+        { $( $imp:item )* }
+        $members:tt
+        { [ $( $prop_doc:tt $prop_getter_name:ident: $prop_type:ty, )* ]
+            [ $( $prop_setter_name:ident : $prop_setter_value_type:tt => $prop_setter_setter:ident, )* ] }
+    } => { $crate::py_class_impl! {
+        { $($tail)* }
+        $class $py $info $slots
+        /* impl: */ {
+            $($imp)*
+            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<$value_type> = {} }] }
+        }
+        $members
+        /* props: */ {
+            [ $( $prop_doc $prop_getter_name: $prop_type, )*
+            ]
+            [ $( $prop_setter_name : $prop_setter_value_type => $prop_setter_setter, )*
+                $name : [ $value_type ] => $setter_name,
+            ]
         }
     }};
 

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -39,7 +39,7 @@ macro_rules! py_class_impl {
             $gc:tt,
             /* data: */ [ $( { $data_offset:expr, $data_name:ident, $data_ty:ty, $init_expr:expr, $init_ty:ty } )* ]
         }
-        $slots:tt { $( $imp:item )* } $members:tt
+        $slots:tt { $( $imp:item )* } $members:tt $props:tt
     } => {
         $crate::py_coerce_item! {
             $($class_visibility)* struct $class { _unsafe_inner: $crate::PyObject }
@@ -182,7 +182,7 @@ macro_rules! py_class_impl {
                     }
 
                     fn init($py: $crate::Python, module_name: Option<&str>) -> $crate::PyResult<$crate::PyType> {
-                        $crate::py_class_type_object_dynamic_init!($class, $py, TYPE_OBJECT, module_name, $slots);
+                        $crate::py_class_type_object_dynamic_init!($class, $py, TYPE_OBJECT, module_name, $slots $props);
                         $crate::py_class_init_members!($class, $py, TYPE_OBJECT, $members);
                         unsafe {
                             if $crate::_detail::ffi::PyType_Ready(&mut TYPE_OBJECT) == 0 {
@@ -208,7 +208,7 @@ macro_rules! py_class_impl {
         }
         $slots:tt
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py
@@ -243,7 +243,7 @@ macro_rules! py_class_impl {
                 }
             }
         }
-        $members
+        $members $props
     }};
     { { @shared data $data_name:ident : $data_type:ty; $($tail:tt)* }
         $class:ident $py:ident
@@ -256,7 +256,7 @@ macro_rules! py_class_impl {
         }
         $slots:tt
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py
@@ -292,7 +292,7 @@ macro_rules! py_class_impl {
                 }
             }
         }
-        $members
+        $members $props
     }};
     { { def __traverse__(&$slf:tt, $visit:ident) $body:block $($tail:tt)* }
         $class:ident $py:ident
@@ -308,7 +308,7 @@ macro_rules! py_class_impl {
         }
         $slots:tt
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py
@@ -335,7 +335,7 @@ macro_rules! py_class_impl {
                 }
             }
         }
-        $members
+        $members $props
     }};
     { { def __clear__ (&$slf:ident) $body:block $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -344,7 +344,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -363,7 +363,7 @@ macro_rules! py_class_impl {
                 }
             }
         }
-        $members
+        $members $props
     }};
     { { def __abs__(&$slf:ident) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -373,7 +373,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -389,7 +389,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __abs__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __abs__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -403,7 +403,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -419,7 +419,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __add__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __add__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -445,7 +445,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -461,7 +461,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __and__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __and__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -479,7 +479,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -495,7 +495,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __bool__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __bool__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -508,7 +508,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -523,7 +523,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __call__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
     { {  def __call__ (&$slf:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -532,7 +532,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -550,7 +550,7 @@ macro_rules! py_class_impl {
                 [] ($($p)+,)
             }
         }
-        $members
+        $members $props
     }};
 
     { { def __cmp__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -572,7 +572,7 @@ macro_rules! py_class_impl {
             $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -588,7 +588,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : Option<&$item_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __contains__(&$slf:ident, $item:ident : &$item_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -598,7 +598,7 @@ macro_rules! py_class_impl {
             $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -614,7 +614,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : &$item_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __contains__(&$slf:ident, $item:ident : $item_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -624,7 +624,7 @@ macro_rules! py_class_impl {
             $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -640,7 +640,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : $item_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __contains__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -668,7 +668,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -683,7 +683,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __delitem__(&$slf:ident, $key:ident : &$key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -695,7 +695,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -710,7 +710,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __delitem__(&$slf:ident, $key:ident : $key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -722,7 +722,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -737,7 +737,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __delitem__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -792,7 +792,7 @@ macro_rules! py_class_impl {
             $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -812,7 +812,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __getitem__(&$slf:ident, $key:ident : &$key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -823,7 +823,7 @@ macro_rules! py_class_impl {
             $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -843,7 +843,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __getitem__(&$slf:ident, $key:ident : $key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -854,7 +854,7 @@ macro_rules! py_class_impl {
             $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -874,7 +874,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __getitem__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -891,7 +891,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -906,7 +906,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __hash__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __hash__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -920,7 +920,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -936,7 +936,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __iadd__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -946,7 +946,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -962,7 +962,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __iadd__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -972,7 +972,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -988,7 +988,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __iadd__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1002,7 +1002,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1018,7 +1018,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __iand__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1028,7 +1028,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1044,7 +1044,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __iand__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1054,7 +1054,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1070,7 +1070,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __iand__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1088,7 +1088,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1104,7 +1104,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ifloordiv__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1114,7 +1114,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1130,7 +1130,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ifloordiv__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1140,7 +1140,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1156,7 +1156,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __ifloordiv__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1170,7 +1170,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1186,7 +1186,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ilshift__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1196,7 +1196,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1212,7 +1212,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ilshift__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1222,7 +1222,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1238,7 +1238,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __ilshift__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1252,7 +1252,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1268,7 +1268,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imatmul__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1278,7 +1278,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1294,7 +1294,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imatmul__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1304,7 +1304,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1320,7 +1320,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __imatmul__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1334,7 +1334,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1350,7 +1350,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imod__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1360,7 +1360,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1376,7 +1376,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imod__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1386,7 +1386,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1402,7 +1402,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __imod__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1416,7 +1416,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1432,7 +1432,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imul__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1442,7 +1442,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1458,7 +1458,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __imul__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1468,7 +1468,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1484,7 +1484,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __imul__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1514,7 +1514,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1530,7 +1530,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __invert__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __invert__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1544,7 +1544,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1560,7 +1560,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ior__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1570,7 +1570,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1586,7 +1586,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ior__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1596,7 +1596,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1612,7 +1612,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __ior__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1630,7 +1630,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1646,7 +1646,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __irshift__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1656,7 +1656,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1672,7 +1672,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __irshift__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1682,7 +1682,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1698,7 +1698,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __irshift__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1712,7 +1712,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1728,7 +1728,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __isub__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1738,7 +1738,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1754,7 +1754,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __isub__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1764,7 +1764,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1780,7 +1780,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __isub__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1793,7 +1793,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1808,7 +1808,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __iter__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __iter__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1822,7 +1822,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1838,7 +1838,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __itruediv__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1848,7 +1848,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1864,7 +1864,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __itruediv__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1874,7 +1874,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1890,7 +1890,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __itruediv__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1904,7 +1904,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1920,7 +1920,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ixor__(&$slf:ident, $other:ident : &$other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1930,7 +1930,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1946,7 +1946,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __ixor__(&$slf:ident, $other:ident : $other_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -1956,7 +1956,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -1972,7 +1972,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __ixor__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -1991,7 +1991,7 @@ macro_rules! py_class_impl {
             $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2011,7 +2011,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __len__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __len__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2029,7 +2029,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2045,7 +2045,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __lshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __lshift__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2071,7 +2071,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2087,7 +2087,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __mul__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __mul__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2105,7 +2105,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2121,7 +2121,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __neg__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __neg__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2134,7 +2134,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2149,7 +2149,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py,__new__($cls: &$crate::PyType,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
     { {  def __new__ ($cls:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2158,7 +2158,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2176,7 +2176,7 @@ macro_rules! py_class_impl {
                 [] ($($p)+,)
             }
         }
-        $members
+        $members $props
     }};
     { { def __next__(&$slf:ident) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2185,7 +2185,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2200,7 +2200,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __next__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __next__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2218,7 +2218,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2234,7 +2234,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __or__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __or__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2248,7 +2248,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2264,7 +2264,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __pos__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __pos__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2297,7 +2297,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2312,7 +2312,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __repr__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __repr__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2329,7 +2329,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2344,7 +2344,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} } { $op : $op_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __richcmp__(&$slf:ident, $other:ident : &$other_name:ty, $op:ident : $op_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2353,7 +2353,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2368,7 +2368,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} } { $op : $op_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __richcmp__(&$slf:ident, $other:ident : $other_name:ty, $op:ident : $op_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2377,7 +2377,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2392,7 +2392,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} } { $op : $op_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __richcmp__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2438,7 +2438,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2454,7 +2454,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __rshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __rshift__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2490,7 +2490,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2505,7 +2505,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} } { $value : $value_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __setitem__(&$slf:ident, $key:ident : &$key_name:ty, $value:ident : $value_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2517,7 +2517,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2532,7 +2532,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} } { $value : $value_name = {} }] }
         }
-        $members
+        $members $props
     }};
     { { def __setitem__(&$slf:ident, $key:ident : $key_name:ty, $value:ident : $value_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
@@ -2544,7 +2544,7 @@ macro_rules! py_class_impl {
             ]
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2559,7 +2559,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} } { $value : $value_name = {} }] }
         }
-        $members
+        $members $props
     }};
 
     { { def __setitem__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2572,7 +2572,7 @@ macro_rules! py_class_impl {
             $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2587,7 +2587,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __str__(&$slf,) $res_type; { $($body)* } [] }
         }
-        $members
+        $members $props
     }};
 
     { { def __str__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2601,7 +2601,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2617,7 +2617,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __sub__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __sub__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2639,7 +2639,7 @@ macro_rules! py_class_impl {
             $as_sequence:tt $as_mapping:tt $setdelitem:tt
         }
         { $( $imp:item )* }
-        $members:tt
+        $members:tt $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info
@@ -2655,7 +2655,7 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_class_impl_item! { $class, $py, __xor__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
-        $members
+        $members $props
     }};
 
     { { def __xor__ $($tail:tt)* } $( $stuff:tt )* } => {
@@ -2664,7 +2664,7 @@ macro_rules! py_class_impl {
     { { $(#[doc=$doc:expr])* def $name:ident (&$slf:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots
@@ -2675,12 +2675,12 @@ macro_rules! py_class_impl {
         /* members: */ {
             $( $member_name = $member_expr; )*
             $name = $crate::py_class_instance_method!{$py, $class::$name, { concat!($($doc, "\n"),*) } []};
-        }
+        } $props
     }};
     { { $(#[doc=$doc:expr])* def $name:ident (&$slf:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots
@@ -2694,12 +2694,12 @@ macro_rules! py_class_impl {
         /* members: */ {
             $( $member_name = $member_expr; )*
             $name = $crate::py_argparse_parse_plist_impl!{py_class_instance_method {$py, $class::$name, { concat!($($doc, "\n"),*) }} [] ($($p)+,)};
-        }
+        } $props
     }};
     { { $(#[doc=$doc:expr])*@classmethod def $name:ident ($cls:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots
@@ -2710,12 +2710,12 @@ macro_rules! py_class_impl {
         /* members: */ {
             $( $member_name = $member_expr; )*
             $name = $crate::py_class_class_method!{$py, $class::$name, { concat!($($doc, "\n"),*) } []};
-        }
+        } $props
     }};
     { { $(#[doc=$doc:expr])*@classmethod def $name:ident ($cls:ident, $($p:tt)+) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots
@@ -2729,12 +2729,12 @@ macro_rules! py_class_impl {
         /* members: */ {
             $( $member_name = $member_expr; )*
             $name = $crate::py_argparse_parse_plist_impl!{py_class_class_method {$py, $class::$name, { concat!($($doc, "\n"),*) }} [] ($($p)+,)};
-        }
+        } $props
     }};
     { { $(#[doc=$doc:expr])* @staticmethod def $name:ident ($($p:tt)*) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt
         { $( $imp:item )* }
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots
@@ -2755,17 +2755,105 @@ macro_rules! py_class_impl {
                 ($($p)*)
             }
             ;
-        }
+        } $props
     }};
     { { static $name:ident = $init:expr; $($tail:tt)* }
         $class:ident $py:ident $info:tt $slots:tt $impls:tt
-        { $( $member_name:ident = $member_expr:expr; )* }
+        { $( $member_name:ident = $member_expr:expr; )* } $props:tt
     } => { $crate::py_class_impl! {
         { $($tail)* }
         $class $py $info $slots $impls
         /* members: */ {
             $( $member_name = $member_expr; )*
             $name = $init;
+        } $props
+    }};
+    { { $(#[doc=$doc:expr])* @property def $name:ident(&$slf:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+        $class:ident $py:ident $info:tt $slots:tt
+        { $( $imp:item )* }
+        $members:tt
+        { [ $( $prop_doc:tt $prop_getter_name:ident: $prop_type:ty, )* ]
+            [ $( $prop_setter_name:ident : $prop_setter_value_type:tt => $prop_setter_setter:ident, )* ] }
+    } => { $crate::py_class_impl! {
+        { $($tail)* }
+        $class $py $info $slots
+        /* impl: */ {
+            $($imp)*
+            $crate::py_class_impl_item! { $class, $py, $name(&$slf,) $res_type; { $($body)* } [] }
+        }
+        $members
+        /* props: */ {
+            [ $( $prop_doc $prop_getter_name: $prop_type, )*
+                { concat!($($doc, "\n"),*) } $name: $res_type,
+            ]
+            [ $( $prop_setter_name : $prop_setter_value_type => $prop_setter_setter, )*
+            ]
+        }
+    }};
+    { { @$name:ident.setter def $setter_name:ident(&$slf:ident, $value:ident : Option<Option<&$value_type:ty>> ) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+        $class:ident $py:ident $info:tt $slots:tt
+        { $( $imp:item )* }
+        $members:tt
+        { [ $( $prop_doc:tt $prop_getter_name:ident: $prop_type:ty, )* ]
+            [ $( $prop_setter_name:ident : $prop_setter_value_type:tt => $prop_setter_setter:ident, )* ] }
+    } => { $crate::py_class_impl! {
+        { $($tail)* }
+        $class $py $info $slots
+        /* impl: */ {
+            $($imp)*
+            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<Option<&$value_type>> = {} }] }
+        }
+        $members
+        /* props: */ {
+            [ $( $prop_doc $prop_getter_name: $prop_type, )*
+            ]
+            [ $( $prop_setter_name : $prop_setter_value_type => $prop_setter_setter, )*
+                $name : [ Option<&$value_type> ] => $setter_name,
+            ]
+        }
+    }};
+    { { @$name:ident.setter def $setter_name:ident(&$slf:ident, $value:ident : Option<&$value_type:ty> ) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+        $class:ident $py:ident $info:tt $slots:tt
+        { $( $imp:item )* }
+        $members:tt
+        { [ $( $prop_doc:tt $prop_getter_name:ident: $prop_type:ty, )* ]
+            [ $( $prop_setter_name:ident : $prop_setter_value_type:tt => $prop_setter_setter:ident, )* ] }
+    } => { $crate::py_class_impl! {
+        { $($tail)* }
+        $class $py $info $slots
+        /* impl: */ {
+            $($imp)*
+            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<&$value_type> = {} }] }
+        }
+        $members
+        /* props: */ {
+            [ $( $prop_doc $prop_getter_name: $prop_type, )*
+            ]
+            [ $( $prop_setter_name : $prop_setter_value_type => $prop_setter_setter, )*
+                $name : [ &$value_type ] => $setter_name,
+            ]
+        }
+    }};
+    { { @$name:ident.setter def $setter_name:ident(&$slf:ident, $value:ident : Option<$value_type:ty> ) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
+        $class:ident $py:ident $info:tt $slots:tt
+        { $( $imp:item )* }
+        $members:tt
+        { [ $( $prop_doc:tt $prop_getter_name:ident: $prop_type:ty, )* ]
+            [ $( $prop_setter_name:ident : $prop_setter_value_type:tt => $prop_setter_setter:ident, )* ] }
+    } => { $crate::py_class_impl! {
+        { $($tail)* }
+        $class $py $info $slots
+        /* impl: */ {
+            $($imp)*
+            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<$value_type> = {} }] }
+        }
+        $members
+        /* props: */ {
+            [ $( $prop_doc $prop_getter_name: $prop_type, )*
+            ]
+            [ $( $prop_setter_name : $prop_setter_value_type => $prop_setter_setter, )*
+                $name : [ $value_type ] => $setter_name,
+            ]
         }
     }};
 

--- a/src/py_class/slots.rs
+++ b/src/py_class/slots.rs
@@ -88,6 +88,7 @@ macro_rules! py_class_type_object_dynamic_init {
             $as_mapping:tt
             $setdelitem:tt
         }
+        $props:tt
     ) => {
         unsafe {
             $type_object.init_ob_type(&mut $crate::_detail::ffi::PyType_Type);
@@ -101,6 +102,7 @@ macro_rules! py_class_type_object_dynamic_init {
             $crate::py_class_as_sequence!($as_sequence);
         *(unsafe { &mut $type_object.tp_as_number }) = $crate::py_class_as_number!($as_number);
         $crate::py_class_as_mapping!($type_object, $as_mapping, $setdelitem);
+        *(unsafe { &mut $type_object.tp_getset }) = $crate::py_class_tp_getset!($class, $props);
     };
 }
 
@@ -258,16 +260,19 @@ macro_rules! py_class_call_slot_impl_with_ref {
         $py:ident,
         $slf:ident,
         $f:ident,
-        $arg:ident: [ Option<&$arg_type:ty> ]
+        $arg:ident: [ Option<&$arg_type:ty> ],
+        $arg_normal:expr,
+        $arg_if_none:expr,
+        $arg_if_some:expr
         $(, $extra_arg:ident)*
     ) => {{
         if $arg.as_ptr() == unsafe { $crate::_detail::ffi::Py_None() } {
-            Ok($slf.$f($py, None $(, $extra_arg)*))
+            Ok($slf.$f($py, $arg_if_none $(, $extra_arg)*))
         } else {
             <$arg_type as $crate::RefFromPyObject>::with_extracted(
                 $py,
                 &$arg,
-                |arg: &$arg_type| $slf.$f($py, Some(arg) $(, $extra_arg)*)
+                |$arg: &$arg_type| $slf.$f($py, $arg_if_some $(, $extra_arg)*)
             )
         }
     }};
@@ -276,13 +281,16 @@ macro_rules! py_class_call_slot_impl_with_ref {
         $py:ident,
         $slf:ident,
         $f:ident,
-        $arg:ident: [ &$arg_type:ty ]
+        $arg:ident: [ &$arg_type:ty ],
+        $arg_normal:expr,
+        $arg_if_none:expr,
+        $arg_if_some:expr
         $(, $extra_arg:ident)*
     ) => {{
         <$arg_type as $crate::RefFromPyObject>::with_extracted(
             $py,
             &$arg,
-            |arg: &$arg_type| $slf.$f($py, arg $(, $extra_arg)*)
+            |$arg: &$arg_type| $slf.$f($py, $arg_normal $(, $extra_arg)*)
         )
     }};
 
@@ -290,11 +298,14 @@ macro_rules! py_class_call_slot_impl_with_ref {
         $py:ident,
         $slf:ident,
         $f:ident,
-        $arg:ident: [ $arg_type:ty ]
+        $arg:ident: [ $arg_type:ty ],
+        $arg_normal:expr,
+        $arg_if_none:expr,
+        $arg_if_some:expr
         $(, $extra_arg:ident)*
     ) => {{
         <$arg_type as $crate::FromPyObject>::extract($py, &$arg)
-            .map(|arg| $slf.$f($py, arg $(, $extra_arg)*))
+            .map(|$arg| $slf.$f($py, $arg_normal $(, $extra_arg)*))
     }};
 }
 
@@ -329,7 +340,15 @@ macro_rules! py_class_binary_slot {
                 let slf =
                     $crate::PyObject::from_borrowed_ptr(py, slf).unchecked_cast_into::<$class>();
                 let arg = $crate::PyObject::from_borrowed_ptr(py, arg);
-                let ret = match py_class_call_slot_impl_with_ref!(py, slf, $f, arg: $arg_type) {
+                let ret = match py_class_call_slot_impl_with_ref!(
+                    py,
+                    slf,
+                    $f,
+                    arg: $arg_type,
+                    arg,
+                    None,
+                    Some(arg)
+                ) {
                     Ok(r) => r,
                     Err(e) => Err(e),
                 };
@@ -359,8 +378,16 @@ macro_rules! py_class_ternary_slot {
                 let arg2 = $crate::PyObject::from_borrowed_ptr(py, arg2);
                 let ret = match <$arg2_type as $crate::FromPyObject>::extract(py, &arg2) {
                     Ok(arg2) => {
-                        match py_class_call_slot_impl_with_ref!(py, slf, $f, arg1: $arg1_type, arg2)
-                        {
+                        match py_class_call_slot_impl_with_ref!(
+                            py,
+                            slf,
+                            $f,
+                            arg1: $arg1_type,
+                            arg1,
+                            None,
+                            Some(arg1),
+                            arg2
+                        ) {
                             Ok(r) => r,
                             Err(e) => Err(e),
                         }
@@ -413,7 +440,16 @@ macro_rules! py_class_richcompare_slot {
                 let arg = $crate::PyObject::from_borrowed_ptr(py, arg);
                 let ret = match $crate::py_class::slots::extract_op(py, op) {
                     Ok(op) => {
-                        match py_class_call_slot_impl_with_ref!(py, slf, $f, arg: $arg_type, op) {
+                        match py_class_call_slot_impl_with_ref!(
+                            py,
+                            slf,
+                            $f,
+                            arg: $arg_type,
+                            arg,
+                            None,
+                            Some(arg),
+                            op
+                        ) {
                             Ok(r) => r.map(|r| r.into_py_object(py).into_object()),
                             Err(e) => Ok(py.NotImplemented()),
                         }
@@ -446,7 +482,15 @@ macro_rules! py_class_contains_slot {
                     let slf = $crate::PyObject::from_borrowed_ptr(py, slf)
                         .unchecked_cast_into::<$class>();
                     let arg = $crate::PyObject::from_borrowed_ptr(py, arg);
-                    let ret = match py_class_call_slot_impl_with_ref!(py, slf, $f, arg: $arg_type) {
+                    let ret = match py_class_call_slot_impl_with_ref!(
+                        py,
+                        slf,
+                        $f,
+                        arg: $arg_type,
+                        arg,
+                        None,
+                        Some(arg)
+                    ) {
                         Ok(r) => r,
                         Err(e) => $crate::py_class::slots::type_error_to_false(py, e),
                     };
@@ -659,4 +703,111 @@ pub unsafe extern "C" fn sq_item(
     let ret = ffi::PyObject_GetItem(obj, arg);
     ffi::Py_DECREF(arg);
     ret
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! py_class_prop_getter {
+    ($class:ident :: $f:ident) => {{
+        unsafe extern "C" fn wrap_getter(
+            slf: *mut $crate::_detail::ffi::PyObject,
+            _closure: *mut $crate::_detail::libc::c_void,
+        ) -> *mut $crate::_detail::ffi::PyObject {
+            const LOCATION: &'static str = concat!(stringify!($class), ".", stringify!($f), "{}");
+            $crate::_detail::handle_callback(
+                LOCATION,
+                $crate::_detail::PyObjectCallbackConverter,
+                |py| {
+                    let slf = $crate::PyObject::from_borrowed_ptr(py, slf)
+                        .unchecked_cast_into::<$class>();
+                    let ret = slf.$f(py);
+                    $crate::PyDrop::release_ref(slf, py);
+                    ret
+                },
+            )
+        }
+        Some(wrap_getter)
+    }};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! py_class_prop_setter {
+    ($class:ident :: $f:ident, $value_type:tt) => {{
+        unsafe extern "C" fn wrap_setter(
+            slf: *mut $crate::_detail::ffi::PyObject,
+            obj: *mut $crate::_detail::ffi::PyObject,
+            _closure: *mut $crate::_detail::libc::c_void,
+        ) -> $crate::_detail::libc::c_int {
+            const LOCATION: &'static str = concat!(stringify!($class), ".", stringify!($f), "{}");
+            $crate::_detail::handle_callback(
+                LOCATION,
+                $crate::py_class::slots::UnitCallbackConverter,
+                |py| {
+                    let slf = $crate::PyObject::from_borrowed_ptr(py, slf)
+                        .unchecked_cast_into::<$class>();
+                    let ret = if obj.is_null() {
+                        slf.$f(py, None)
+                    } else {
+                        let obj = $crate::PyObject::from_borrowed_ptr(py, obj);
+                        let ret = match py_class_call_slot_impl_with_ref!(
+                            py,
+                            slf,
+                            $f,
+                            obj: $value_type,
+                            Some(obj),
+                            Some(None),
+                            Some(Some(obj))
+                        ) {
+                            Ok(r) => r,
+                            Err(e) => Err(e),
+                        };
+                        $crate::PyDrop::release_ref(obj, py);
+                        ret
+                    };
+                    $crate::PyDrop::release_ref(slf, py);
+                    ret
+                },
+            )
+        }
+        Some(wrap_setter)
+    }};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! py_class_tp_getset {
+    ( $class:ident, { [] [] } ) => { 0 as *mut $crate::_detail::ffi::PyGetSetDef };
+    (
+        $class:ident,
+        {
+            [ $( { $( $doc:tt )* } $getter_name:ident: $prop_type:ty, )* ]
+            [ $( $setter_name:ident: $value_type:tt => $setter_setter:ident, )* ]
+        }
+    ) => {{
+        let mut index = 0usize;
+        $( let $getter_name = index; index += 1; )*
+        unsafe {
+            static mut GETSET: &mut [$crate::_detail::ffi::PyGetSetDef] = &mut [
+                $($crate::_detail::ffi::PyGetSetDef {
+                    name: concat!(stringify!($getter_name), "\0").as_ptr() as *mut _,
+                    get: py_class_prop_getter!($class::$getter_name),
+                    set: None,
+                    doc: concat!($( $doc )*, "\0").as_ptr() as *mut _,
+                    closure: 0 as *mut _,
+                },)*
+                $crate::_detail::ffi::PyGetSetDef {
+                    name: 0 as *mut _,
+                    get: None,
+                    set: None,
+                    doc: 0 as *mut _,
+                    closure: 0 as *mut _,
+                }
+            ];
+            $(
+                GETSET[$setter_name].set = py_class_prop_setter!($class::$setter_setter, $value_type);
+            )*
+            GETSET.as_ptr() as *mut _
+        }
+    }};
 }

--- a/tests/test_class.rs
+++ b/tests/test_class.rs
@@ -1188,3 +1188,79 @@ fn context_manager() {
     );
     assert!(c.exit_called(py).get());
 }
+
+py_class!(class Properties |py| {
+    data value: Cell<i32>;
+    data value_by_ref: RefCell<String>;
+    data value_by_opt_ref: RefCell<String>;
+
+    def __repr__(&self) -> PyResult<String> {
+        Ok(format!("P({:?} {:?} {:?})",
+            self.value(py).get(),
+            self.value_by_ref(py).borrow(),
+            self.value_by_opt_ref(py).borrow()))
+    }
+
+    @property def prop(&self) -> PyResult<i32> {
+        Ok(self.value(py).get())
+    }
+
+    @prop.setter def set_prop(&self, value: Option<i32>) -> PyResult<()> {
+        self.value(py).set(value.unwrap_or(0));
+        Ok(())
+    }
+
+    @property def prop_by_ref(&self) -> PyResult<String> {
+        Ok(self.value_by_ref(py).borrow().to_string())
+    }
+
+    @prop_by_ref.setter def set_prop_by_ref(&self, value: Option<&str>) -> PyResult<()> {
+        *self.value_by_ref(py).borrow_mut() = value.unwrap_or("DELETED").to_string();
+        Ok(())
+    }
+
+    @property def prop_by_opt_ref(&self) -> PyResult<String> {
+        Ok(self.value_by_opt_ref(py).borrow().to_string())
+    }
+
+    @prop_by_opt_ref.setter def set_prop_by_opt_ref(&self, value: Option<Option<&str>>) -> PyResult<()> {
+        let value = value.unwrap_or(Some("DELETED")).unwrap_or("NO VALUE");
+        *self.value_by_opt_ref(py).borrow_mut() = value.to_string();
+        Ok(())
+    }
+
+    @property def read_only(&self) -> PyResult<bool> {
+        Ok(self.value(py).get() != 0)
+    }
+});
+
+#[test]
+fn properties() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let c = Properties::create_instance(
+        py,
+        Cell::new(0),
+        RefCell::new(String::new()),
+        RefCell::new(String::new()),
+    )
+    .unwrap();
+    py_run!(py, c, "assert c.prop == 0");
+    py_run!(py, c, "assert not c.read_only");
+    py_run!(py, c, "c.prop = 42");
+    assert_eq!(c.value(py).get(), 42);
+    py_run!(py, c, "assert c.read_only");
+    assert!(c.read_only(py).unwrap());
+
+    py_run!(py, c, "c.prop_by_ref = 'testing'");
+    py_run!(py, c, "assert c.prop_by_ref == 'testing'");
+
+    py_run!(py, c, "c.prop_by_opt_ref = 'something'");
+    assert_eq!(*c.value_by_opt_ref(py).borrow(), "something");
+    py_run!(py, c, "c.prop_by_opt_ref = None");
+    py_run!(py, c, "repr(c) == 'P(42, \"testing\" \"NO VALUE\")'");
+
+    py_run!(py, c, "del c.prop_by_opt_ref");
+    py_run!(py, c, "repr(c) == 'P(42, \"testing\" \"DELETED\")'");
+}

--- a/tests/test_class.rs
+++ b/tests/test_class.rs
@@ -1229,7 +1229,8 @@ py_class!(class Properties |py| {
         Ok(())
     }
 
-    @property def read_only(&self) -> PyResult<bool> {
+    /// docs for match
+    @property def r#match(&self) -> PyResult<bool> {
         Ok(self.value(py).get() != 0)
     }
 });
@@ -1246,12 +1247,19 @@ fn properties() {
         RefCell::new(String::new()),
     )
     .unwrap();
+
+    py_run!(
+        py,
+        c,
+        "assert 'docs for match' in c.__class__.match.__doc__"
+    );
+
     py_run!(py, c, "assert c.prop == 0");
-    py_run!(py, c, "assert not c.read_only");
+    py_run!(py, c, "assert not c.match");
     py_run!(py, c, "c.prop = 42");
     assert_eq!(c.value(py).get(), 42);
-    py_run!(py, c, "assert c.read_only");
-    assert!(c.read_only(py).unwrap());
+    py_run!(py, c, "assert c.match");
+    assert!(c.r#match(py).unwrap());
 
     py_run!(py, c, "c.prop_by_ref = 'testing'");
     py_run!(py, c, "assert c.prop_by_ref == 'testing'");

--- a/tests/test_function.rs
+++ b/tests/test_function.rs
@@ -99,6 +99,38 @@ fn inline_two_args() {
     );
 }
 
+#[test]
+fn opt_args() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let obj = py_fn!(py, f(a: Option<&str>, b: &str, c: Option<&str> = None) -> PyResult<String> {
+        drop(py);
+        Ok(format!("a: {:?}  b: {:?}  c: {:?}", a, b, c))
+    });
+
+    assert_eq!(
+        obj.call(py, (py.None(), "string"), None)
+            .unwrap()
+            .extract::<String>(py)
+            .unwrap(),
+        r#"a: None  b: "string"  c: None"#,
+    );
+    assert_eq!(
+        obj.call(py, ("double", "string", py.None()), None)
+            .unwrap()
+            .extract::<String>(py)
+            .unwrap(),
+        r#"a: Some("double")  b: "string"  c: None"#,
+    );
+    assert_eq!(
+        obj.call(py, ("triple", "string", "args"), None)
+            .unwrap()
+            .extract::<String>(py)
+            .unwrap(),
+        r#"a: Some("triple")  b: "string"  c: Some("args")"#,
+    );
+}
+
 /* TODO: reimplement flexible sig support
 #[test]
 fn flexible_sig() {


### PR DESCRIPTION
Add support for defining Python properties (attributes with getters and optional setters) in Rust.

Properties are defined inside `py_class!` with:

    @property def property_name(&self) -> PyResult<PropertyType> { ... }

where `property_name` is the name in Python, and `PropertyType` is any type that impls `ToPyObject`.

Property setters can optionally be defined as:

    @property_name.setter def set_property_name(
        &self,
        value: Option<PropertyType>
    ) -> PyResult<()> { ... }

If the value is `None` then the caller is deleting the property (`del obj.property_name`).

If the value is `Some(x)` then the caller is setting the property to `x`.

For setters, the `PropertyType` can be any type that impls `FromPyObject`, or a reference or optional reference to any type that impls `RefFromPyObject`.

In the latter case, the type of `value` is `Option<Option<&PropertyType>>`, where `None` means the value is being deleted, `Some(None)` means the property is being set to Python `None`, and `Some(Some(x))` means the property is being set to `x`.