### PR TITLE
Add more import APIs

### DIFF
--- a/python3-sys/src/import.rs
+++ b/python3-sys/src/import.rs
@@ -98,4 +98,24 @@ extern "C" {
     pub static mut PyImport_Inittab: *mut _inittab;
 
     pub fn PyImport_ExtendInittab(newtab: *const _inittab) -> c_int;
+
+    #[cfg(not(Py_3_7))]
+    pub fn _PyImport_FindBuiltin(name: *const c_char) -> *mut PyObject;
+    #[cfg(Py_3_7)]
+    pub fn _PyImport_FindBuiltin(name: *const c_char, modules: *mut PyObject) -> *mut PyObject;
+
+    pub fn _PyImport_FindExtensionObject(name: *mut PyObject, filename: *mut PyObject) -> *mut PyObject;
+
+    #[cfg(Py_3_7)]
+    pub fn _PyImport_FindExtensionObjectEx(name: *mut PyObject, filename: *mut PyObject, modules: *mut PyObject) -> *mut PyObject;
+
+    #[cfg(not(Py_3_7))]
+    pub fn _PyImport_FixupBuiltin(module: *mut PyObject, name: *const c_char) -> c_int;
+    #[cfg(Py_3_7)]
+    pub fn _PyImport_FixupBuiltin(module: *mut PyObject, name: *const c_char, modules: *mut PyObject) -> c_int;
+
+    #[cfg(not(Py_3_7))]
+    pub fn _PyImport_FixupExtensionObject(module: *mut PyObject, name: *mut PyObject, filename: *mut PyObject) -> c_int;
+    #[cfg(Py_3_7)]
+    pub fn _PyImport_FixupExtensionObject(module: *mut PyObject, name: *mut PyObject, filename: *mut PyObject, modules: *mut PyObject) -> c_int;
 }

--- a/python3-sys/src/modsupport.rs
+++ b/python3-sys/src/modsupport.rs
@@ -122,3 +122,9 @@ pub unsafe fn PyModule_FromDefAndSpec(def: *mut PyModuleDef, spec: *mut PyObject
         },
     )
 }
+
+#[cfg(not(Py_LIMITED_API))]
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
+    pub static mut _Py_PackageContext: *const c_char;
+}


### PR DESCRIPTION
I need some of these APIs to support in-memory extension module
importing in PyOxidizer. While I was adding the ones I needed, I
figured I would include some other missing symbols from
import.h as well.