### PR TITLE
Release 0.5.0 and some doc clarifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/dgrunwald/rust-cpython/compare/0.4.1...HEAD
+[Unreleased]: https://github.com/dgrunwald/rust-cpython/compare/0.5.0...HEAD
+
+## 0.5.0 - 2020-04-08
+
+- [properties (attributes with getter/setters defined in Rust][208] (PR by [@markbt])
+- [adoption of 2018 edition and general code modernization][204] (PR by [@markbt])
+- [reference extraction for slot functions and optional reference extraction][207] (PR by [@markbt])
+- [PEP-587 initialization APIs (python3-sys for Python≥3.8)][211] (PR by [@indygreg])
+- [more import APIs (python3-sys)][210] (PR by [@indygreg])
 
 ## 0.4.1 - 2020-02-03
 - [link-time inconsistency with build config][135] (original PR by [@svevang] adapted as [202])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cpython"
-version = "0.4.1"
+version = "0.5.0"
 description = "Bindings to Python"
 authors = ["Daniel Grunwald <daniel@danielgrunwald.de>"]
 readme = "README.md"
@@ -41,12 +41,12 @@ paste = "0.1"
 [dependencies.python27-sys]
 optional = true
 path = "python27-sys"
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies.python3-sys]
 optional = true
 path = "python3-sys"
-version = "0.4.1"
+version = "0.5.0"
 
 [features]
 default = ["python3-sys"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use `cpython`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cpython = "0.4"
+cpython = "0.5"
 ```
 
 #### Example program displaying the value of `sys.version`:
@@ -70,7 +70,7 @@ name = "rust2py"
 crate-type = ["cdylib"]
 
 [dependencies.cpython]
-version = "0.4"
+version = "0.5"
 features = ["extension-module"]
 ```
 

--- a/extensions/hello/Cargo.toml
+++ b/extensions/hello/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Daniel Grunwald <daniel@danielgrunwald.de>"]
 edition = "2018"
 

--- a/python27-sys/Cargo.toml
+++ b/python27-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python27-sys"
-version = "0.4.1"
+version = "0.5.0"
 description = "FFI Declarations for Python 2.7"
 readme = "README.md"
 keywords = [

--- a/python3-sys/Cargo.toml
+++ b/python3-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python3-sys"
-version = "0.4.1"
+version = "0.5.0"
 description = "FFI Declarations for Python 3"
 readme = "README.md"
 keywords = [

--- a/src/py_class/py_class.rs
+++ b/src/py_class/py_class.rs
@@ -171,7 +171,10 @@ Declares a static method callable from Python.
 
 `@property_name.setter def set_method_name(&self, value: Option<impl FromPyObject>) -> PyResult<()> { ... }`
 
-Declares a property (attribute with code for getting and optionally setting) accessible from Python.
+Declares a Python data attribute backed by Rust methods to
+get its value and, optionally, to set or delete it.
+
+### Setter details
 
 * The setter is optional.  If omitted, the attribute will be read-only.
 * Unlike Python, the setter method name must be different from the property name.

--- a/src/py_class/py_class.rs
+++ b/src/py_class/py_class.rs
@@ -176,10 +176,13 @@ get its value and, optionally, to set or delete it.
 
 ### Setter details
 
-* The setter is optional.  If omitted, the attribute will be read-only.
+* The setter is optional.  If omitted, the attribute will be read-only
+  and any setting or deleting attempt will raise `AttributeError`.
 * Unlike Python, the setter method name must be different from the property name.
   The setter method name is used to call the setter from Rust.
-* If value is `None` then the property is being deleted.
+* A `None` value represents that the property is being deleted, for instance
+  with Python `del`.
+  As with Python properties, what should happen is entirely up to the implementation.
 * The value type can be any type that implements `FromPyObject`, or a reference or
   optional reference to any type that implements `RefFromPyObject`.  In the latter
   case, the type of the value is `Option<Option<&impl RefFromPyObject>>`, where

--- a/tests/test_class.rs
+++ b/tests/test_class.rs
@@ -1261,6 +1261,10 @@ fn properties() {
     py_run!(py, c, "assert c.match");
     assert!(c.r#match(py).unwrap());
 
+    // Instead of really deleting, our setter sets back to 0
+    py_run!(py, c, "delattr(c, 'prop')");
+    py_run!(py, c, "assert c.prop == 0");
+
     py_run!(py, c, "c.prop_by_ref = 'testing'");
     py_run!(py, c, "assert c.prop_by_ref == 'testing'");
 


### PR DESCRIPTION
Tried to make some things more explicit in the documentation of properties, and then proceed to the 0.5.0 release.

I'll merge this myself, so that I can upload to `crates.io` and put a tag right away.