### PR TITLE
Format code and suppress unused_parens warnings

### DIFF
--- a/python27-sys/src/lib.rs
+++ b/python27-sys/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
+#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case, unused_parens)]
 
 pub use crate::boolobject::*;
 pub use crate::bufferobject::*;

--- a/python3-sys/src/import.rs
+++ b/python3-sys/src/import.rs
@@ -104,18 +104,38 @@ extern "C" {
     #[cfg(Py_3_7)]
     pub fn _PyImport_FindBuiltin(name: *const c_char, modules: *mut PyObject) -> *mut PyObject;
 
-    pub fn _PyImport_FindExtensionObject(name: *mut PyObject, filename: *mut PyObject) -> *mut PyObject;
+    pub fn _PyImport_FindExtensionObject(
+        name: *mut PyObject,
+        filename: *mut PyObject,
+    ) -> *mut PyObject;
 
     #[cfg(Py_3_7)]
-    pub fn _PyImport_FindExtensionObjectEx(name: *mut PyObject, filename: *mut PyObject, modules: *mut PyObject) -> *mut PyObject;
+    pub fn _PyImport_FindExtensionObjectEx(
+        name: *mut PyObject,
+        filename: *mut PyObject,
+        modules: *mut PyObject,
+    ) -> *mut PyObject;
 
     #[cfg(not(Py_3_7))]
     pub fn _PyImport_FixupBuiltin(module: *mut PyObject, name: *const c_char) -> c_int;
     #[cfg(Py_3_7)]
-    pub fn _PyImport_FixupBuiltin(module: *mut PyObject, name: *const c_char, modules: *mut PyObject) -> c_int;
+    pub fn _PyImport_FixupBuiltin(
+        module: *mut PyObject,
+        name: *const c_char,
+        modules: *mut PyObject,
+    ) -> c_int;
 
     #[cfg(not(Py_3_7))]
-    pub fn _PyImport_FixupExtensionObject(module: *mut PyObject, name: *mut PyObject, filename: *mut PyObject) -> c_int;
+    pub fn _PyImport_FixupExtensionObject(
+        module: *mut PyObject,
+        name: *mut PyObject,
+        filename: *mut PyObject,
+    ) -> c_int;
     #[cfg(Py_3_7)]
-    pub fn _PyImport_FixupExtensionObject(module: *mut PyObject, name: *mut PyObject, filename: *mut PyObject, modules: *mut PyObject) -> c_int;
+    pub fn _PyImport_FixupExtensionObject(
+        module: *mut PyObject,
+        name: *mut PyObject,
+        filename: *mut PyObject,
+        modules: *mut PyObject,
+    ) -> c_int;
 }

--- a/python3-sys/src/lib.rs
+++ b/python3-sys/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
+#![allow(non_camel_case_types, non_snake_case, non_upper_case_globals, unused_parens)]
 #![cfg_attr(Py_LIMITED_API, allow(unused_imports))]
 
 // old: marked with TODO


### PR DESCRIPTION
Run the code through `rustfmt` again - the latest additions to python3-sys were not formatted.

Suppress the `unused_parens` warnings in the sys crates.  These trigger on code like:
```
pub const PyBUF_STRIDES: c_int = (0x0010 | PyBUF_ND);
```

We should keep these as they match the C header.