### PR TITLE
add PyDictProxy, see #221

### DIFF
--- a/python3-sys/src/descrobject.rs
+++ b/python3-sys/src/descrobject.rs
@@ -1,8 +1,9 @@
 use libc::{c_char, c_int, c_void};
 
 use crate::methodobject::PyMethodDef;
-use crate::object::{PyObject, PyTypeObject};
+use crate::object::*;
 use crate::structmember::PyMemberDef;
+use crate::pyport::Py_ssize_t;
 
 pub type getter = unsafe extern "C" fn(slf: *mut PyObject, closure: *mut c_void) -> *mut PyObject;
 
@@ -31,6 +32,18 @@ impl Clone for PyGetSetDef {
         *self
     }
 }
+
+
+#[inline(always)]
+pub unsafe fn PyDictProxy_Check(op: *mut PyObject) -> c_int {
+    PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC)
+}
+
+#[inline(always)]
+pub unsafe fn PyDictProxy_CheckExact(op: *mut PyObject) -> c_int {
+    (Py_TYPE(op) == &mut PyDictProxy_Type) as c_int
+}
+
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/src/objects/descrobject.rs
+++ b/src/objects/descrobject.rs
@@ -1,0 +1,64 @@
+use std::ptr;
+
+use crate::conversion::ToPyObject;
+use crate::err::{self, PyErr, PyResult};
+use crate::ffi;
+use crate::objects::{PyObject, PyTuple};
+use crate::python::{Python, PythonObject, ToPythonPointer};
+
+/// Represents a read-only Python dictionary
+pub struct PyDictProxy(PyObject);
+
+pyobject_newtype!(PyDictProxy, PyDictProxy_Check, PyDictProxy_Type);
+
+impl PyDictProxy {
+    #[inline]
+    pub fn len(&self, _py: Python) -> usize {
+        unsafe { ffi::PyObject_Size(self.0.as_ptr()) as usize }
+    }
+
+    pub fn get_item<K>(&self, py: Python, key: K) -> Option<PyObject>
+    where
+        K: ToPyObject,
+    {
+    	key.with_borrowed_ptr(py, |key| unsafe {
+            PyObject::from_borrowed_ptr_opt(py, ffi::PyObject_GetItem(self.0.as_ptr(), key))
+        })
+    }
+
+    pub fn contains<K>(&self, py: Python, key: K) -> PyResult<bool>
+    where
+        K: ToPyObject,
+    {
+        key.with_borrowed_ptr(py, |key| unsafe {
+            match ffi::PyMapping_HasKey(self.0.as_ptr(), key) {
+                1 => Ok(true),
+                0 => Ok(false),
+                _ => Err(PyErr::fetch(py)),
+            }
+        })
+    }
+
+    pub fn keys(&self, py: Python) -> PyObject {
+        // Returns a PySequence object
+        unsafe {
+        	PyObject::from_borrowed_ptr(py, ffi::PyMapping_Keys(self.0.as_ptr()))
+        }
+    }
+
+    pub fn values(&self, py: Python) -> PyObject {
+        // Returns a PySequence object
+        unsafe {
+        	PyObject::from_borrowed_ptr(py, ffi::PyMapping_Values(self.0.as_ptr()))
+        }
+    }
+
+    pub fn items(&self, py: Python) -> PyObject {
+        // Returns a PySequence object
+        unsafe {
+        	PyObject::from_borrowed_ptr(py, ffi::PyMapping_Items(self.0.as_ptr()))
+        }
+    }
+}
+
+

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -39,6 +39,7 @@ pub use self::num::{PyFloat, PyLong};
 pub use self::sequence::PySequence;
 pub use self::set::PySet;
 pub use self::tuple::{NoArgs, PyTuple};
+pub use self::descrobject::PyDictProxy;
 
 #[macro_export]
 macro_rules! pyobject_newtype(
@@ -146,6 +147,7 @@ mod set;
 mod string;
 mod tuple;
 mod typeobject;
+mod descrobject;
 
 #[cfg(feature = "python27-sys")]
 pub mod oldstyle;


### PR DESCRIPTION
The mappingproxy functions are defined as static in https://github.com/python/cpython/blob/3.7/Objects/descrobject.c#L806 and tbh, dunno what's the point is with _Py_IDENTIFIER(keys) and _PyObject_CallMethodId for example in mappingproxy_keys so went directly to the source in abstracts by checking _Py_IDENTIFIER(keys) in https://github.com/python/cpython/blob/088b63ea7a8331a3e34bc93c3b873c60354b4fad/Tools/c-analyzer/known.tsv#L1212 etc.. https://github.com/python/cpython/blob/4a21e57fe55076c77b0ee454e1994ca544d09dc0/Objects/abstract.c#L2303

Anyway, everything works as expected and so on.