### PR TITLE
WIP: Add support for the buffer protocol

### DIFF
--- a/python3-sys/src/memoryobject.rs
+++ b/python3-sys/src/memoryobject.rs
@@ -21,6 +21,7 @@ extern "C" {
         size: Py_ssize_t,
         flags: c_int,
     ) -> *mut PyObject;
+    pub fn PyMemoryView_FromBuffer(view: *mut Py_buffer) -> *mut PyObject;
     pub fn PyMemoryView_GetContiguous(
         base: *mut PyObject,
         buffertype: c_int,

--- a/python3-sys/src/object.rs
+++ b/python3-sys/src/object.rs
@@ -109,13 +109,13 @@ mod bufferinfo {
         }
     }
 
-    pub type getbufferproc = extern "C" fn(
+    pub type getbufferproc = unsafe extern "C" fn(
         arg1: *mut crate::object::PyObject,
         arg2: *mut Py_buffer,
         arg3: c_int,
     ) -> c_int;
     pub type releasebufferproc =
-        extern "C" fn(arg1: *mut crate::object::PyObject, arg2: *mut Py_buffer) -> ();
+        unsafe extern "C" fn(arg1: *mut crate::object::PyObject, arg2: *mut Py_buffer) -> ();
 
     /// Maximum number of dimensions
     pub const PyBUF_MAX_NDIM: c_int = 64;

--- a/python3-sys/src/object.rs
+++ b/python3-sys/src/object.rs
@@ -430,6 +430,10 @@ mod typeobject {
             unsafe { core::mem::zeroed() }
         }
     }
+    pub const PyBufferProcs_INIT: PyBufferProcs = PyBufferProcs {
+        bf_getbuffer: None,
+        bf_releasebuffer: None,
+    };
 
     #[repr(C)]
     #[derive(Copy)]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -665,11 +665,6 @@ impl_element!(f64, Float);
 ///
 /// It is unsafe because its implementation needs to uphold certain invariants.
 /// See the method docs for more details.
-// TODO:
-// - Buffer request can not fail yet
-// - Buffer can not actually store data inside the object itself, only in a
-//   standalone owned object, which usually means a heap allocated reference counted
-//   container.
 pub unsafe trait BufferHandle: 'static + Send {
     /// Returns the data of `Self` as a continous array of bytes.
     ///

--- a/src/py_class/py_class.rs
+++ b/src/py_class/py_class.rs
@@ -465,6 +465,10 @@ macro_rules! py_class {
                 /* as_number */   [ /* slot: expr, */ ]
                 /* as_sequence */ [ /* slot: expr, */ ]
                 /* as_mapping */  [ /* slot: expr, */ ]
+                /* as_buffer */ [
+                    bf_getbuffer: {},
+                    bf_releasebuffer: {},
+                ]
                 /* setitem_delitem */ [
                     sdi_setitem: {},
                     sdi_delitem: {},
@@ -495,6 +499,10 @@ macro_rules! py_class {
                 /* as_number */   [ /* slot: expr, */ ]
                 /* as_sequence */ [ /* slot: expr, */ ]
                 /* as_mapping */  [ /* slot: expr, */ ]
+                /* as_buffer */ [
+                    bf_getbuffer: {},
+                    bf_releasebuffer: {},
+                ]
                 /* setitem_delitem */ [
                     sdi_setitem: {},
                     sdi_delitem: {},

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -341,7 +341,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -353,7 +353,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_clear: $crate::py_class_tp_clear!($class),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -370,7 +370,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -383,7 +383,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_absolute: $crate::py_class_unary_slot!($class::__abs__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -400,7 +400,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -413,7 +413,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_add: $crate::py_class_binary_numeric_slot!($class::__add__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -442,7 +442,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -455,7 +455,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_and: $crate::py_class_binary_numeric_slot!($class::__and__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -476,7 +476,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -489,7 +489,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_nonzero: $crate::py_class_unary_slot!($class::__bool__, $crate::_detail::libc::c_int, $crate::py_class::slots::BoolConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -501,11 +501,42 @@ macro_rules! py_class_impl {
     { { def __bool__ $($tail:tt)* } $( $stuff:tt )* } => {
         $crate::py_error! { "Invalid signature for operator __bool__" }
     };
+    { { def __buffer__ (&$slf:ident) -> $res_type:ty $body:block $($tail:tt)* }
+        $class:ident $py:ident $info:tt
+        /* slots: */ {
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            /* as_buffer */ [
+                bf_getbuffer: {},
+                bf_releasebuffer: {},
+            ]
+            $setdelitem:tt
+        }
+        { $( $imp:item )* }
+        $members:tt $props:tt
+    } => { $crate::py_class_impl! {
+        { $($tail)* }
+        $class $py $info
+        /* slots: */ {
+            $type_slots $as_number $as_sequence $as_mapping
+            /* as_buffer */ [
+                bf_getbuffer: { $crate::py_class_buffer_slot!(bf_getbuffer, $class::__buffer__) },
+                bf_releasebuffer: { $crate::py_class_buffer_slot!(bf_releasebuffer, $class::__buffer__) },
+            ]
+            $setdelitem
+        }
+        /* impl: */ {
+            $($imp)*
+            impl $class {
+                fn __buffer__(&$slf, $py: $crate::Python<'_>) -> $res_type $body
+            }
+        }
+        $members $props
+    }};
     { {  def __call__ (&$slf:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -517,7 +548,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_call: $crate::py_class_call_slot!{$class::__call__ []},
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -529,7 +560,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -541,7 +572,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_call: $crate::py_argparse_parse_plist_impl!{py_class_call_slot {$class::__call__} [] ($($p)+,)},
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -569,7 +600,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
-            $as_mapping:tt $setdelitem:tt
+            $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -582,7 +613,7 @@ macro_rules! py_class_impl {
                 $( $sq_slot_name : $sq_slot_value, )*
                 sq_contains: $crate::py_class_contains_slot!($class::__contains__, [Option<&$item_name>]),
             ]
-            $as_mapping $setdelitem
+            $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -595,7 +626,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
-            $as_mapping:tt $setdelitem:tt
+            $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -608,7 +639,7 @@ macro_rules! py_class_impl {
                 $( $sq_slot_name : $sq_slot_value, )*
                 sq_contains: $crate::py_class_contains_slot!($class::__contains__, [&$item_name]),
             ]
-            $as_mapping $setdelitem
+            $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -621,7 +652,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
-            $as_mapping:tt $setdelitem:tt
+            $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -634,7 +665,7 @@ macro_rules! py_class_impl {
                 $( $sq_slot_name : $sq_slot_value, )*
                 sq_contains: $crate::py_class_contains_slot!($class::__contains__, [$item_name]),
             ]
-            $as_mapping $setdelitem
+            $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -661,7 +692,7 @@ macro_rules! py_class_impl {
     { { def __delitem__(&$slf:ident, $key:ident : Option<&$key_name:ty>) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value:tt,
                 sdi_delitem: {},
@@ -673,7 +704,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value,
                 sdi_delitem: { $crate::py_class_binary_slot!($class::__delitem__, [Option<&$key_name>], $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
@@ -688,7 +719,7 @@ macro_rules! py_class_impl {
     { { def __delitem__(&$slf:ident, $key:ident : &$key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value:tt,
                 sdi_delitem: {},
@@ -700,7 +731,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value,
                 sdi_delitem: { $crate::py_class_binary_slot!($class::__delitem__, [&$key_name], $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
@@ -715,7 +746,7 @@ macro_rules! py_class_impl {
     { { def __delitem__(&$slf:ident, $key:ident : $key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value:tt,
                 sdi_delitem: {},
@@ -727,7 +758,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value,
                 sdi_delitem: { $crate::py_class_binary_slot!($class::__delitem__, [$key_name], $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
@@ -789,7 +820,7 @@ macro_rules! py_class_impl {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
             /* as_mapping */ [ $( $mp_slot_name:ident : $mp_slot_value:expr, )* ]
-            $setdelitem:tt
+            $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -806,7 +837,7 @@ macro_rules! py_class_impl {
                 $( $mp_slot_name : $mp_slot_value, )*
                 mp_subscript: $crate::py_class_binary_slot!($class::__getitem__, [Option<&$key_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $setdelitem
+            $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -820,7 +851,7 @@ macro_rules! py_class_impl {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
             /* as_mapping */ [ $( $mp_slot_name:ident : $mp_slot_value:expr, )* ]
-            $setdelitem:tt
+            $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -837,7 +868,7 @@ macro_rules! py_class_impl {
                 $( $mp_slot_name : $mp_slot_value, )*
                 mp_subscript: $crate::py_class_binary_slot!($class::__getitem__, [&$key_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $setdelitem
+            $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -851,7 +882,7 @@ macro_rules! py_class_impl {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
             /* as_mapping */ [ $( $mp_slot_name:ident : $mp_slot_value:expr, )* ]
-            $setdelitem:tt
+            $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -868,7 +899,7 @@ macro_rules! py_class_impl {
                 $( $mp_slot_name : $mp_slot_value, )*
                 mp_subscript: $crate::py_class_binary_slot!($class::__getitem__, [$key_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $setdelitem
+            $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -888,7 +919,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -900,7 +931,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_hash: $crate::py_class_unary_slot!($class::__hash__, $crate::Py_hash_t, $crate::py_class::slots::HashConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -917,7 +948,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -930,7 +961,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_add: $crate::py_class_binary_slot!($class::__iadd__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -943,7 +974,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -956,7 +987,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_add: $crate::py_class_binary_slot!($class::__iadd__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -969,7 +1000,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -982,7 +1013,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_add: $crate::py_class_binary_slot!($class::__iadd__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -999,7 +1030,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1012,7 +1043,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_and: $crate::py_class_binary_slot!($class::__iand__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1025,7 +1056,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1038,7 +1069,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_and: $crate::py_class_binary_slot!($class::__iand__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1051,7 +1082,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1064,7 +1095,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_and: $crate::py_class_binary_slot!($class::__iand__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1085,7 +1116,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1098,7 +1129,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_floor_divide: $crate::py_class_binary_slot!($class::__ifloordiv__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1111,7 +1142,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1124,7 +1155,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_floor_divide: $crate::py_class_binary_slot!($class::__ifloordiv__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1137,7 +1168,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1150,7 +1181,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_floor_divide: $crate::py_class_binary_slot!($class::__ifloordiv__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1167,7 +1198,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1180,7 +1211,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_lshift: $crate::py_class_binary_slot!($class::__ilshift__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1193,7 +1224,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1206,7 +1237,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_lshift: $crate::py_class_binary_slot!($class::__ilshift__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1219,7 +1250,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1232,7 +1263,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_lshift: $crate::py_class_binary_slot!($class::__ilshift__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1249,7 +1280,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1262,7 +1293,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_matrix_multiply: $crate::py_class_binary_slot!($class::__imatmul__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1275,7 +1306,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1288,7 +1319,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_matrix_multiply: $crate::py_class_binary_slot!($class::__imatmul__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1301,7 +1332,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1314,7 +1345,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_matrix_multiply: $crate::py_class_binary_slot!($class::__imatmul__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1331,7 +1362,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1344,7 +1375,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_remainder: $crate::py_class_binary_slot!($class::__imod__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1357,7 +1388,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1370,7 +1401,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_remainder: $crate::py_class_binary_slot!($class::__imod__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1383,7 +1414,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1396,7 +1427,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_remainder: $crate::py_class_binary_slot!($class::__imod__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1413,7 +1444,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1426,7 +1457,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_multiply: $crate::py_class_binary_slot!($class::__imul__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1439,7 +1470,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1452,7 +1483,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_multiply: $crate::py_class_binary_slot!($class::__imul__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1465,7 +1496,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1478,7 +1509,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_multiply: $crate::py_class_binary_slot!($class::__imul__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1511,7 +1542,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1524,7 +1555,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_invert: $crate::py_class_unary_slot!($class::__invert__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1541,7 +1572,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1554,7 +1585,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_or: $crate::py_class_binary_slot!($class::__ior__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1567,7 +1598,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1580,7 +1611,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_or: $crate::py_class_binary_slot!($class::__ior__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1593,7 +1624,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1606,7 +1637,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_or: $crate::py_class_binary_slot!($class::__ior__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1627,7 +1658,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1640,7 +1671,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_rshift: $crate::py_class_binary_slot!($class::__irshift__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1653,7 +1684,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1666,7 +1697,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_rshift: $crate::py_class_binary_slot!($class::__irshift__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1679,7 +1710,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1692,7 +1723,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_rshift: $crate::py_class_binary_slot!($class::__irshift__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1709,7 +1740,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1722,7 +1753,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_subtract: $crate::py_class_binary_slot!($class::__isub__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1735,7 +1766,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1748,7 +1779,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_subtract: $crate::py_class_binary_slot!($class::__isub__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1761,7 +1792,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1774,7 +1805,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_subtract: $crate::py_class_binary_slot!($class::__isub__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1790,7 +1821,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1802,7 +1833,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_iter: $crate::py_class_unary_slot!($class::__iter__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1819,7 +1850,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1832,7 +1863,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_true_divide: $crate::py_class_binary_slot!($class::__itruediv__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1845,7 +1876,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1858,7 +1889,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_true_divide: $crate::py_class_binary_slot!($class::__itruediv__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1871,7 +1902,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1884,7 +1915,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_true_divide: $crate::py_class_binary_slot!($class::__itruediv__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1901,7 +1932,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1914,7 +1945,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_xor: $crate::py_class_binary_slot!($class::__ixor__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1927,7 +1958,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1940,7 +1971,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_xor: $crate::py_class_binary_slot!($class::__ixor__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1953,7 +1984,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1966,7 +1997,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_xor: $crate::py_class_binary_slot!($class::__ixor__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1988,7 +2019,7 @@ macro_rules! py_class_impl {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
             /* as_mapping */ [ $( $mp_slot_name:ident : $mp_slot_value:expr, )* ]
-            $setdelitem:tt
+            $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2005,7 +2036,7 @@ macro_rules! py_class_impl {
                 $( $mp_slot_name : $mp_slot_value, )*
                 mp_length: Some($crate::_detail::ffi::PySequence_Size),
             ]
-            $setdelitem
+            $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2026,7 +2057,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2039,7 +2070,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_lshift: $crate::py_class_binary_numeric_slot!($class::__lshift__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2068,7 +2099,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2081,7 +2112,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_multiply: $crate::py_class_binary_numeric_slot!($class::__mul__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2102,7 +2133,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2115,7 +2146,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_negative: $crate::py_class_unary_slot!($class::__neg__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2131,7 +2162,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2143,7 +2174,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_new: $crate::py_class_wrap_newfunc!{$class::__new__ []},
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2155,7 +2186,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2167,7 +2198,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_new: $crate::py_argparse_parse_plist_impl!{py_class_wrap_newfunc {$class::__new__} [] ($($p)+,)},
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2182,7 +2213,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2194,7 +2225,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_iternext: $crate::py_class_unary_slot!($class::__next__, *mut $crate::_detail::ffi::PyObject, $crate::py_class::slots::IterNextResultConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2215,7 +2246,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2228,7 +2259,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_or: $crate::py_class_binary_numeric_slot!($class::__or__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2245,7 +2276,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2258,7 +2289,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_positive: $crate::py_class_unary_slot!($class::__pos__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2294,7 +2325,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2306,7 +2337,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_repr: $crate::py_class_unary_slot!($class::__repr__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PythonObjectCallbackConverter::<$crate::PyString>(std::marker::PhantomData)),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2326,7 +2357,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2338,7 +2369,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_richcompare: $crate::py_class_richcompare_slot!($class::__richcmp__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2350,7 +2381,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2362,7 +2393,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_richcompare: $crate::py_class_richcompare_slot!($class::__richcmp__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2374,7 +2405,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2386,7 +2417,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_richcompare: $crate::py_class_richcompare_slot!($class::__richcmp__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2435,7 +2466,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2448,7 +2479,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_rshift: $crate::py_class_binary_numeric_slot!($class::__rshift__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2483,7 +2514,7 @@ macro_rules! py_class_impl {
     { { def __setitem__(&$slf:ident, $key:ident : Option<&$key_name:ty>, $value:ident : $value_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: {},
                 sdi_delitem: $sdi_delitem_slot_value:tt,
@@ -2495,7 +2526,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: { $crate::py_class_ternary_slot!($class::__setitem__, [Option<&$key_name>], $value_name, $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
                 sdi_delitem: $sdi_delitem_slot_value,
@@ -2510,7 +2541,7 @@ macro_rules! py_class_impl {
     { { def __setitem__(&$slf:ident, $key:ident : &$key_name:ty, $value:ident : $value_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: {},
                 sdi_delitem: $sdi_delitem_slot_value:tt,
@@ -2522,7 +2553,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: { $crate::py_class_ternary_slot!($class::__setitem__, [&$key_name], $value_name, $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
                 sdi_delitem: $sdi_delitem_slot_value,
@@ -2537,7 +2568,7 @@ macro_rules! py_class_impl {
     { { def __setitem__(&$slf:ident, $key:ident : $key_name:ty, $value:ident : $value_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: {},
                 sdi_delitem: $sdi_delitem_slot_value:tt,
@@ -2549,7 +2580,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: { $crate::py_class_ternary_slot!($class::__setitem__, [$key_name], $value_name, $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
                 sdi_delitem: $sdi_delitem_slot_value,
@@ -2569,7 +2600,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2581,7 +2612,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_str: $crate::py_class_unary_slot!($class::__str__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PythonObjectCallbackConverter::<$crate::PyString>(std::marker::PhantomData)),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2598,7 +2629,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2611,7 +2642,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_subtract: $crate::py_class_binary_numeric_slot!($class::__sub__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2636,7 +2667,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2649,7 +2680,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_xor: $crate::py_class_binary_numeric_slot!($class::__xor__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -341,7 +341,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -353,7 +353,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_clear: $crate::py_class_tp_clear!($class),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -370,7 +370,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -383,7 +383,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_absolute: $crate::py_class_unary_slot!($class::__abs__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -400,7 +400,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -413,7 +413,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_add: $crate::py_class_binary_numeric_slot!($class::__add__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -442,7 +442,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -455,7 +455,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_and: $crate::py_class_binary_numeric_slot!($class::__and__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -476,7 +476,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -489,7 +489,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_bool: $crate::py_class_unary_slot!($class::__bool__, $crate::_detail::libc::c_int, $crate::py_class::slots::BoolConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -501,11 +501,42 @@ macro_rules! py_class_impl {
     { { def __bool__ $($tail:tt)* } $( $stuff:tt )* } => {
         $crate::py_error! { "Invalid signature for operator __bool__" }
     };
+    { { def __buffer__ (&$slf:ident) -> $res_type:ty $body:block $($tail:tt)* }
+        $class:ident $py:ident $info:tt
+        /* slots: */ {
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            /* as_buffer */ [
+                bf_getbuffer: {},
+                bf_releasebuffer: {},
+            ]
+            $setdelitem:tt
+        }
+        { $( $imp:item )* }
+        $members:tt $props:tt
+    } => { $crate::py_class_impl! {
+        { $($tail)* }
+        $class $py $info
+        /* slots: */ {
+            $type_slots $as_number $as_sequence $as_mapping
+            /* as_buffer */ [
+                bf_getbuffer: { $crate::py_class_buffer_slot!(bf_getbuffer, $class::__buffer__) },
+                bf_releasebuffer: { $crate::py_class_buffer_slot!(bf_releasebuffer, $class::__buffer__) },
+            ]
+            $setdelitem
+        }
+        /* impl: */ {
+            $($imp)*
+            impl $class {
+                fn __buffer__(&$slf, $py: $crate::Python<'_>) -> $res_type $body
+            }
+        }
+        $members $props
+    }};
     { {  def __call__ (&$slf:ident) -> $res_type:ty { $( $body:tt )* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -517,7 +548,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_call: $crate::py_class_call_slot!{$class::__call__ []},
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -529,7 +560,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -541,7 +572,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_call: $crate::py_argparse_parse_plist_impl!{py_class_call_slot {$class::__call__} [] ($($p)+,)},
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -569,7 +600,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
-            $as_mapping:tt $setdelitem:tt
+            $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -582,7 +613,7 @@ macro_rules! py_class_impl {
                 $( $sq_slot_name : $sq_slot_value, )*
                 sq_contains: $crate::py_class_contains_slot!($class::__contains__, [Option<&$item_name>]),
             ]
-            $as_mapping $setdelitem
+            $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -595,7 +626,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
-            $as_mapping:tt $setdelitem:tt
+            $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -608,7 +639,7 @@ macro_rules! py_class_impl {
                 $( $sq_slot_name : $sq_slot_value, )*
                 sq_contains: $crate::py_class_contains_slot!($class::__contains__, [&$item_name]),
             ]
-            $as_mapping $setdelitem
+            $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -621,7 +652,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
-            $as_mapping:tt $setdelitem:tt
+            $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -634,7 +665,7 @@ macro_rules! py_class_impl {
                 $( $sq_slot_name : $sq_slot_value, )*
                 sq_contains: $crate::py_class_contains_slot!($class::__contains__, [$item_name]),
             ]
-            $as_mapping $setdelitem
+            $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -661,7 +692,7 @@ macro_rules! py_class_impl {
     { { def __delitem__(&$slf:ident, $key:ident : Option<&$key_name:ty>) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value:tt,
                 sdi_delitem: {},
@@ -673,7 +704,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value,
                 sdi_delitem: { $crate::py_class_binary_slot!($class::__delitem__, [Option<&$key_name>], $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
@@ -688,7 +719,7 @@ macro_rules! py_class_impl {
     { { def __delitem__(&$slf:ident, $key:ident : &$key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value:tt,
                 sdi_delitem: {},
@@ -700,7 +731,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value,
                 sdi_delitem: { $crate::py_class_binary_slot!($class::__delitem__, [&$key_name], $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
@@ -715,7 +746,7 @@ macro_rules! py_class_impl {
     { { def __delitem__(&$slf:ident, $key:ident : $key_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value:tt,
                 sdi_delitem: {},
@@ -727,7 +758,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: $sdi_setitem_slot_value,
                 sdi_delitem: { $crate::py_class_binary_slot!($class::__delitem__, [$key_name], $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
@@ -789,7 +820,7 @@ macro_rules! py_class_impl {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
             /* as_mapping */ [ $( $mp_slot_name:ident : $mp_slot_value:expr, )* ]
-            $setdelitem:tt
+            $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -806,7 +837,7 @@ macro_rules! py_class_impl {
                 $( $mp_slot_name : $mp_slot_value, )*
                 mp_subscript: $crate::py_class_binary_slot!($class::__getitem__, [Option<&$key_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $setdelitem
+            $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -820,7 +851,7 @@ macro_rules! py_class_impl {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
             /* as_mapping */ [ $( $mp_slot_name:ident : $mp_slot_value:expr, )* ]
-            $setdelitem:tt
+            $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -837,7 +868,7 @@ macro_rules! py_class_impl {
                 $( $mp_slot_name : $mp_slot_value, )*
                 mp_subscript: $crate::py_class_binary_slot!($class::__getitem__, [&$key_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $setdelitem
+            $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -851,7 +882,7 @@ macro_rules! py_class_impl {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
             /* as_mapping */ [ $( $mp_slot_name:ident : $mp_slot_value:expr, )* ]
-            $setdelitem:tt
+            $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -868,7 +899,7 @@ macro_rules! py_class_impl {
                 $( $mp_slot_name : $mp_slot_value, )*
                 mp_subscript: $crate::py_class_binary_slot!($class::__getitem__, [$key_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $setdelitem
+            $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -888,7 +919,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -900,7 +931,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_hash: $crate::py_class_unary_slot!($class::__hash__, $crate::Py_hash_t, $crate::py_class::slots::HashConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -917,7 +948,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -930,7 +961,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_add: $crate::py_class_binary_slot!($class::__iadd__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -943,7 +974,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -956,7 +987,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_add: $crate::py_class_binary_slot!($class::__iadd__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -969,7 +1000,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -982,7 +1013,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_add: $crate::py_class_binary_slot!($class::__iadd__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -999,7 +1030,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1012,7 +1043,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_and: $crate::py_class_binary_slot!($class::__iand__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1025,7 +1056,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1038,7 +1069,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_and: $crate::py_class_binary_slot!($class::__iand__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1051,7 +1082,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1064,7 +1095,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_and: $crate::py_class_binary_slot!($class::__iand__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1085,7 +1116,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1098,7 +1129,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_floor_divide: $crate::py_class_binary_slot!($class::__ifloordiv__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1111,7 +1142,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1124,7 +1155,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_floor_divide: $crate::py_class_binary_slot!($class::__ifloordiv__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1137,7 +1168,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1150,7 +1181,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_floor_divide: $crate::py_class_binary_slot!($class::__ifloordiv__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1167,7 +1198,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1180,7 +1211,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_lshift: $crate::py_class_binary_slot!($class::__ilshift__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1193,7 +1224,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1206,7 +1237,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_lshift: $crate::py_class_binary_slot!($class::__ilshift__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1219,7 +1250,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1232,7 +1263,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_lshift: $crate::py_class_binary_slot!($class::__ilshift__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1249,7 +1280,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1262,7 +1293,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_matrix_multiply: $crate::py_class_binary_slot!($class::__imatmul__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1275,7 +1306,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1288,7 +1319,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_matrix_multiply: $crate::py_class_binary_slot!($class::__imatmul__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1301,7 +1332,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1314,7 +1345,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_matrix_multiply: $crate::py_class_binary_slot!($class::__imatmul__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1331,7 +1362,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1344,7 +1375,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_remainder: $crate::py_class_binary_slot!($class::__imod__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1357,7 +1388,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1370,7 +1401,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_remainder: $crate::py_class_binary_slot!($class::__imod__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1383,7 +1414,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1396,7 +1427,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_remainder: $crate::py_class_binary_slot!($class::__imod__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1413,7 +1444,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1426,7 +1457,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_multiply: $crate::py_class_binary_slot!($class::__imul__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1439,7 +1470,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1452,7 +1483,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_multiply: $crate::py_class_binary_slot!($class::__imul__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1465,7 +1496,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1478,7 +1509,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_multiply: $crate::py_class_binary_slot!($class::__imul__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1511,7 +1542,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1524,7 +1555,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_invert: $crate::py_class_unary_slot!($class::__invert__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1541,7 +1572,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1554,7 +1585,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_or: $crate::py_class_binary_slot!($class::__ior__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1567,7 +1598,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1580,7 +1611,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_or: $crate::py_class_binary_slot!($class::__ior__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1593,7 +1624,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1606,7 +1637,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_or: $crate::py_class_binary_slot!($class::__ior__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1627,7 +1658,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1640,7 +1671,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_rshift: $crate::py_class_binary_slot!($class::__irshift__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1653,7 +1684,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1666,7 +1697,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_rshift: $crate::py_class_binary_slot!($class::__irshift__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1679,7 +1710,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1692,7 +1723,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_rshift: $crate::py_class_binary_slot!($class::__irshift__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1709,7 +1740,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1722,7 +1753,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_subtract: $crate::py_class_binary_slot!($class::__isub__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1735,7 +1766,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1748,7 +1779,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_subtract: $crate::py_class_binary_slot!($class::__isub__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1761,7 +1792,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1774,7 +1805,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_subtract: $crate::py_class_binary_slot!($class::__isub__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1790,7 +1821,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1802,7 +1833,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_iter: $crate::py_class_unary_slot!($class::__iter__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1819,7 +1850,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1832,7 +1863,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_true_divide: $crate::py_class_binary_slot!($class::__itruediv__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1845,7 +1876,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1858,7 +1889,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_true_divide: $crate::py_class_binary_slot!($class::__itruediv__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1871,7 +1902,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1884,7 +1915,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_true_divide: $crate::py_class_binary_slot!($class::__itruediv__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1901,7 +1932,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1914,7 +1945,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_xor: $crate::py_class_binary_slot!($class::__ixor__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1927,7 +1958,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1940,7 +1971,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_xor: $crate::py_class_binary_slot!($class::__ixor__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1953,7 +1984,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -1966,7 +1997,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_inplace_xor: $crate::py_class_binary_slot!($class::__ixor__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -1988,7 +2019,7 @@ macro_rules! py_class_impl {
             $type_slots:tt $as_number:tt
             /* as_sequence */ [ $( $sq_slot_name:ident : $sq_slot_value:expr, )* ]
             /* as_mapping */ [ $( $mp_slot_name:ident : $mp_slot_value:expr, )* ]
-            $setdelitem:tt
+            $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2005,7 +2036,7 @@ macro_rules! py_class_impl {
                 $( $mp_slot_name : $mp_slot_value, )*
                 mp_length: Some($crate::_detail::ffi::PySequence_Size),
             ]
-            $setdelitem
+            $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2026,7 +2057,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2039,7 +2070,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_lshift: $crate::py_class_binary_numeric_slot!($class::__lshift__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2068,7 +2099,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2081,7 +2112,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_multiply: $crate::py_class_binary_numeric_slot!($class::__mul__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2102,7 +2133,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2115,7 +2146,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_negative: $crate::py_class_unary_slot!($class::__neg__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2131,7 +2162,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2143,7 +2174,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_new: $crate::py_class_wrap_newfunc!{$class::__new__ []},
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2155,7 +2186,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2167,7 +2198,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_new: $crate::py_argparse_parse_plist_impl!{py_class_wrap_newfunc {$class::__new__} [] ($($p)+,)},
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2182,7 +2213,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2194,7 +2225,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_iternext: $crate::py_class_unary_slot!($class::__next__, *mut $crate::_detail::ffi::PyObject, $crate::py_class::slots::IterNextResultConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2215,7 +2246,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2228,7 +2259,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_or: $crate::py_class_binary_numeric_slot!($class::__or__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2245,7 +2276,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2258,7 +2289,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_positive: $crate::py_class_unary_slot!($class::__pos__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2294,7 +2325,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2306,7 +2337,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_repr: $crate::py_class_unary_slot!($class::__repr__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PythonObjectCallbackConverter::<$crate::PyString>(std::marker::PhantomData)),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2326,7 +2357,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2338,7 +2369,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_richcompare: $crate::py_class_richcompare_slot!($class::__richcmp__, [Option<&$other_name>], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2350,7 +2381,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2362,7 +2393,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_richcompare: $crate::py_class_richcompare_slot!($class::__richcmp__, [&$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2374,7 +2405,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2386,7 +2417,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_richcompare: $crate::py_class_richcompare_slot!($class::__richcmp__, [$other_name], *mut $crate::_detail::ffi::PyObject, $crate::_detail::PyObjectCallbackConverter),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2435,7 +2466,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2448,7 +2479,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_rshift: $crate::py_class_binary_numeric_slot!($class::__rshift__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2483,7 +2514,7 @@ macro_rules! py_class_impl {
     { { def __setitem__(&$slf:ident, $key:ident : Option<&$key_name:ty>, $value:ident : $value_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: {},
                 sdi_delitem: $sdi_delitem_slot_value:tt,
@@ -2495,7 +2526,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: { $crate::py_class_ternary_slot!($class::__setitem__, [Option<&$key_name>], $value_name, $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
                 sdi_delitem: $sdi_delitem_slot_value,
@@ -2510,7 +2541,7 @@ macro_rules! py_class_impl {
     { { def __setitem__(&$slf:ident, $key:ident : &$key_name:ty, $value:ident : $value_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: {},
                 sdi_delitem: $sdi_delitem_slot_value:tt,
@@ -2522,7 +2553,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: { $crate::py_class_ternary_slot!($class::__setitem__, [&$key_name], $value_name, $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
                 sdi_delitem: $sdi_delitem_slot_value,
@@ -2537,7 +2568,7 @@ macro_rules! py_class_impl {
     { { def __setitem__(&$slf:ident, $key:ident : $key_name:ty, $value:ident : $value_name:ty) -> $res_type:ty { $($body:tt)* } $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
-            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt
+            $type_slots:tt $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt
             /* setdelitem */ [
                 sdi_setitem: {},
                 sdi_delitem: $sdi_delitem_slot_value:tt,
@@ -2549,7 +2580,7 @@ macro_rules! py_class_impl {
         { $($tail)* }
         $class $py $info
         /* slots: */ {
-            $type_slots $as_number $as_sequence $as_mapping
+            $type_slots $as_number $as_sequence $as_mapping $as_buffer
             /* setdelitem */ [
                 sdi_setitem: { $crate::py_class_ternary_slot!($class::__setitem__, [$key_name], $value_name, $crate::_detail::libc::c_int, $crate::py_class::slots::UnitCallbackConverter) },
                 sdi_delitem: $sdi_delitem_slot_value,
@@ -2569,7 +2600,7 @@ macro_rules! py_class_impl {
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
-            $as_number:tt $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_number:tt $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2581,7 +2612,7 @@ macro_rules! py_class_impl {
                 $( $tp_slot_name : $tp_slot_value, )*
                 tp_str: $crate::py_class_unary_slot!($class::__str__, *mut $crate::_detail::ffi::PyObject, $crate::_detail::PythonObjectCallbackConverter::<$crate::PyString>(std::marker::PhantomData)),
             ]
-            $as_number $as_sequence $as_mapping $setdelitem
+            $as_number $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2598,7 +2629,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2611,7 +2642,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_subtract: $crate::py_class_binary_numeric_slot!($class::__sub__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*
@@ -2636,7 +2667,7 @@ macro_rules! py_class_impl {
         /* slots: */ {
             $type_slots:tt
             /* as_number */ [ $( $nb_slot_name:ident : $nb_slot_value:expr, )* ]
-            $as_sequence:tt $as_mapping:tt $setdelitem:tt
+            $as_sequence:tt $as_mapping:tt $as_buffer:tt $setdelitem:tt
         }
         { $( $imp:item )* }
         $members:tt $props:tt
@@ -2649,7 +2680,7 @@ macro_rules! py_class_impl {
                 $( $nb_slot_name : $nb_slot_value, )*
                 nb_xor: $crate::py_class_binary_numeric_slot!($class::__xor__),
             ]
-            $as_sequence $as_mapping $setdelitem
+            $as_sequence $as_mapping $as_buffer $setdelitem
         }
         /* impl: */ {
             $($imp)*


### PR DESCRIPTION
This adds initial support for implementing the [buffer protocol](https://docs.python.org/3/c-api/buffer.html) via `py_class! {}`.

This works by defining a magic method:

```python
def __buffer__(&self) -> PyResult<MyBuffer> { ... }
```

where `MyBuffer` has to implement the following trait.

```rust
pub unsafe trait BufferHandle: 'static + Send {
    /// Returns the data of `Self` as a continous array of bytes.
    ///
    /// # Safety
    ///
    /// This needs to return an address that remains valid
    /// and stable if `self` gets moved or transformed to or from a void pointer.
    fn as_bytes(&self) -> &[u8];

    /// Convert `self` into an owned void pointer.
    ///
    /// # Safety
    ///
    /// The returned pointer has to be a valid pointer that
    /// can be converted back to `Self`.
    fn to_owned_void_pointer(self) -> *mut libc::c_void;

    /// Convert an owned void pointer back to `Self`. This takes owenrship of the pointer.
    ///
    /// # Safety
    ///
    /// The passed `ptr` has been created by this trait, and is only
    /// used at most once to convert back to `Self`.
    unsafe fn from_owned_void_pointer(ptr: *mut libc::c_void) -> Self;
}
```

## Remaining issues

- Does not work for Python2.7 for reasons I don't understand yet. The support for the "new" python 3 buffer interface exists in 2.7 with all the right type definitions, but the tests fails at runtime with "cannot make memory view because object does not have the buffer interface", so I've disabled it there for now. Help would be appreciated with this, as I'm not actively using 2.7 (which is eol, besides 😅).
- Only supports exporting a read-only byte array view for now.
- The `BufferHandle` API does not allow rejecting a buffer request.
- The `BufferHandle` API does not allow keeping ownership of the memory inside the class, as I was not sure if that can be safely done.


---

This partially fixes #190