### PR TITLE
Add some missing APIs for PyBytes

### DIFF
--- a/python3-sys/src/bytesobject.rs
+++ b/python3-sys/src/bytesobject.rs
@@ -45,3 +45,9 @@ extern "C" {
         len: *mut Py_ssize_t,
     ) -> c_int;
 }
+
+#[cfg_attr(windows, link(name = "pythonXY"))]
+#[cfg(not(Py_LIMITED_API))]
+extern "C" {
+    pub fn _PyBytes_Resize(arg1: *mut *mut PyObject, arg2: Py_ssize_t) -> c_int;
+}


### PR DESCRIPTION
As part of porting some performance sensitive C extension code to Rust,
I came across some missing APIs in the Python bindings.

My use case is I want to create a `PyBytes` instance to hold data that
isn't available yet in order to avoid the memory copy that
`PyBytes_FromStringAndSize()` will normally perform when given an input
buffer. The C API provides a facility for this by passing a null pointer
into said function.

This commit introduces a new constructor on the `PyBytes` type to create
an instance whose contents are uninitialized. And in order to initialize
that data, we introduce a new method to obtain a mutable slice of that
backing buffer.

In addition, we also define C bindings to the `_PyBytes_Resize`
function, which can be used to resize an existing `PyBytes` instance.
Since this API isn't part of limited API and we don't have a feature
flag in the `cpython` crate to gate access to non-limited APIs, I'm
unsure how to expose this to the `PyBytes` type. So it is just defined
at the bindings layer for now.

There is room to debate whether these functions should be annotated as
`unsafe` and whether the new API is the most reasonable. An alternative
API might be something like
`new_initialize(size: usize, f: fn(&mut [u8])-> usize) -> PyBytes`,
which would create an unitialized buffer then pass it to a callback,
which would populate the data then return the new size of the buffer.
This feels a bit more ergonomic to me. But we could always add that
later.