### PR TITLE
Add a way to disable converting PyString to unicode on Python 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,11 @@ python-3-4 = ["python3-sys/python-3-4"]
 # This scenario should be rare.
 no-auto-initialize = []
 
+# Only affect Python 2.
+# Once set, `PyString` and `String` converts to only `bytes` (aka. `str` on
+# Python 2). Non-ascii string will no longer be converted to `unicode`.
+py2-no-auto-unicode-promotion = []
+
 [workspace]
 members = ["python27-sys", "python3-sys", "extensions/hello"]
 

--- a/src/objects/string.rs
+++ b/src/objects/string.rs
@@ -234,7 +234,9 @@ impl PyString {
     /// Creates a new Python string object.
     ///
     /// On Python 2.7, this function will create a byte string if the
-    /// input string is ASCII-only; and a unicode string otherwise.
+    /// feature `py2-no-auto-unicode-promotion` is set, or the input
+    /// input string is ASCII-only; otherwise, the input string will be
+    /// converted to a unicode string.
     /// Use `PyUnicode::new()` to always create a unicode string.
     ///
     /// On Python 3.x, this function always creates unicode `str` objects.
@@ -243,7 +245,7 @@ impl PyString {
     pub fn new(py: Python, s: &str) -> PyString {
         #[cfg(feature = "python27-sys")]
         fn new_impl(py: Python, s: &str) -> PyString {
-            if s.is_ascii() {
+            if cfg!(feature = "py2-no-auto-unicode-promotion") || s.is_ascii() {
                 PyBytes::new(py, s.as_bytes()).into_basestring()
             } else {
                 PyUnicode::new(py, s).into_basestring()


### PR DESCRIPTION
The current logic that converts a PyString to either bytes or unicode
on Python 2 makes the `PyString` or `String` type less useful in
applications that pay closer attention to the actual type of bytes vs
string.

Add a feature, once set, PyString and String will be consistently
converted to the `str` type on both Python 2 and Python 3, regardless
of their actual content. This meets expections of type-sensitive
applications that still use Python 2.

The feature is disabled by default conservatively for backwards
compatibility.