### PR TITLE
Initial serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,11 @@ appveyor = { repository = "dgrunwald/rust-cpython" }
 libc = "0.2"
 num-traits = "0.2"
 paste = "0.1"
+serde = { version = "1", features = ["derive"], optional = true }
+
+[dev-dependencies]
+serde_bytes = { version = "0.11" }
+serde_cbor = { version = "0.11" }
 
 # These features are both optional, but you must pick one to 
 # indicate which python ffi you are trying to bind to.
@@ -50,6 +55,9 @@ version = "0.5.1"
 
 [features]
 default = ["python3-sys"]
+
+# Enable serde support that converts between a serde type and PyObject.
+serde-convert = ["serde"]
 
 # Deprecated: nonnull feature no longer has any effect;
 # std::ptr::NonNull is now used unconditionally.

--- a/Makefile
+++ b/Makefile
@@ -45,14 +45,14 @@ build: src/py_class/py_class_impl2.rs src/py_class/py_class_impl3.rs python27-sy
 	cargo build $(CARGO_FLAGS)
 
 test: build
-	cargo test $(CARGO_FLAGS)
+	cargo test --features serde-convert $(CARGO_FLAGS)
 ifeq ($(NIGHTLY),1)
 # ast-json output is only supported on nightly
 	python$(PY) tests/check_symbols.py
 endif
 
 doc: build
-	cargo doc --no-deps $(CARGO_FLAGS)
+	cargo doc --no-deps --features serde-convert $(CARGO_FLAGS)
 
 extensions: build
 	make -C extensions/tests PY=$(PY)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,9 @@ mod pythonrun;
 pub mod py_class;
 mod sharedref;
 
+#[cfg(feature = "serde-convert")]
+pub mod serde;
+
 /// Private re-exports for macros. Do not use.
 #[doc(hidden)]
 pub mod _detail {

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,0 +1,364 @@
+use super::Error;
+use crate::FromPyObject;
+use crate::NoArgs;
+use crate::ObjectProtocol;
+use crate::PyBytes;
+use crate::PyDict;
+use crate::PyIterator;
+use crate::PyList;
+use crate::PyObject;
+use crate::PyResult;
+use crate::PyString;
+use crate::PyTuple;
+use crate::Python;
+use crate::PythonObject;
+use crate::ToPyObject;
+use ::serde::{de, de::Visitor};
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// Deserialize from Python object.
+pub fn from_py_object<'de, T>(py: Python, obj: PyObject) -> Result<T>
+where
+    T: de::Deserialize<'de>,
+{
+    let mut deserializer = Deserializer::new(py, obj);
+    T::deserialize(&mut deserializer)
+}
+
+struct Deserializer<'gil> {
+    py: Python<'gil>,
+    obj: PyObject,
+
+    /// Iterator of `obj`. Constructed on demand.
+    obj_iter: Option<PyIterator<'gil>>,
+
+    /// Used by `MapAccess`. The `iter` produces `(key, value)` at a time, the
+    /// `value` is temporarily stored here for `MapAccess::next_value_seed` to
+    /// pick up.
+    pending_value: Option<PyObject>,
+}
+
+impl<'gil> Deserializer<'gil> {
+    /// Constructs from
+    fn new(py: Python<'gil>, obj: PyObject) -> Self {
+        Self {
+            py,
+            obj,
+            obj_iter: None,
+            pending_value: None,
+        }
+    }
+
+    /// Returns the next item from a Python iterator (obj should be an iterable).
+    fn next(&mut self) -> Result<Option<PyObject>> {
+        match self.obj_iter {
+            None => {
+                // Convert `obj` to a Python iterator object.
+                // Usually this is a no-op for a type that is already an iterator.
+                //
+                // Special case: for PyDict, call the "items" method first to get
+                // an iterator of (key, value) instead of just keys.
+                let iter = if let Ok(_) = self.extract::<PyDict>() {
+                    let items = self.obj.call_method(self.py, "items", NoArgs, None)?;
+                    items.iter(self.py)?
+                } else {
+                    self.obj.iter(self.py)?
+                };
+                self.obj_iter = Some(iter);
+                self.next()
+            }
+            Some(ref mut iter) => iter.next().transpose().map_err(Into::into),
+        }
+    }
+
+    /// Attempt to convert `obj` to a given type.
+    fn extract<T>(&self) -> Result<T>
+    where
+        for<'s> T: FromPyObject<'s>,
+    {
+        self.obj.extract(self.py).map_err(Into::into)
+    }
+
+    /// Test whether `self.obj` is `None` in Python.
+    fn is_none(&self) -> bool {
+        self.obj == self.py.None()
+    }
+}
+
+impl<'de, 'a, 'gil> de::Deserializer<'de> for &'a mut Deserializer<'gil> {
+    type Error = Error;
+
+    fn deserialize_any<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        if self.is_none() {
+            v.visit_none()
+        } else if self.extract::<bool>().is_ok() {
+            self.deserialize_bool(v)
+        } else if self.extract::<PyDict>().is_ok() {
+            self.deserialize_map(v)
+        } else if self.extract::<PyList>().is_ok() {
+            self.deserialize_seq(v)
+        } else if self.extract::<PyTuple>().is_ok() {
+            self.deserialize_seq(v)
+        } else if self.extract::<PyBytes>().is_ok() {
+            self.deserialize_bytes(v)
+        } else if self.extract::<PyString>().is_ok() {
+            self.deserialize_string(v)
+        } else if self.extract::<i64>().is_ok() {
+            self.deserialize_i64(v)
+        } else if self.extract::<u64>().is_ok() {
+            self.deserialize_u64(v)
+        } else if self.extract::<f64>().is_ok() {
+            self.deserialize_f64(v)
+        } else {
+            // Maybe an iterator? Treat it as a sequence.
+            self.deserialize_seq(v)
+        }
+    }
+
+    fn deserialize_bool<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_bool(self.extract()?)
+    }
+
+    fn deserialize_i8<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_i8(self.extract()?)
+    }
+
+    fn deserialize_i16<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_i16(self.extract()?)
+    }
+
+    fn deserialize_i32<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_i32(self.extract()?)
+    }
+
+    fn deserialize_i64<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_i64(self.extract()?)
+    }
+
+    fn deserialize_u8<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_u8(self.extract()?)
+    }
+
+    fn deserialize_u16<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_u16(self.extract()?)
+    }
+
+    fn deserialize_u32<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_u32(self.extract()?)
+    }
+
+    fn deserialize_u64<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_u64(self.extract()?)
+    }
+
+    fn deserialize_f32<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_f32(self.extract()?)
+    }
+
+    fn deserialize_f64<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_f64(self.extract()?)
+    }
+
+    fn deserialize_string<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_string(self.extract()?)
+    }
+
+    fn deserialize_char<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        self.deserialize_string(v)
+    }
+
+    fn deserialize_str<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        self.deserialize_string(v)
+    }
+
+    fn deserialize_bytes<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        let pybytes: PyBytes = self.extract()?;
+        v.visit_bytes(pybytes.data(self.py))
+    }
+
+    fn deserialize_byte_buf<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        self.deserialize_bytes(v)
+    }
+
+    fn deserialize_option<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        if self.is_none() {
+            v.visit_none()
+        } else {
+            v.visit_some(self)
+        }
+    }
+
+    fn deserialize_unit<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V: Visitor<'de>>(self, _: &'static str, v: V) -> Result<V::Value> {
+        self.deserialize_unit(v)
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _: &'static str,
+        v: V,
+    ) -> Result<V::Value> {
+        v.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_seq(self)
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(self, _len: usize, v: V) -> Result<V::Value> {
+        self.deserialize_seq(v)
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        v: V,
+    ) -> Result<V::Value> {
+        self.deserialize_seq(v)
+    }
+
+    fn deserialize_map<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        v.visit_map(self)
+    }
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        v: V,
+    ) -> Result<V::Value> {
+        self.deserialize_map(v)
+    }
+
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        v: V,
+    ) -> Result<V::Value> {
+        v.visit_enum(self)
+    }
+
+    fn deserialize_identifier<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        self.deserialize_string(v)
+    }
+
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, v: V) -> Result<V::Value> {
+        self.deserialize_any(v)
+    }
+}
+
+impl<'de, 'a, 'gil> de::SeqAccess<'de> for &'a mut Deserializer<'gil> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.next()? {
+            Some(obj) => {
+                let mut deserializer = Deserializer::new(self.py, obj);
+                seed.deserialize(&mut deserializer).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+impl<'de, 'a, 'gil> de::MapAccess<'de> for &'a mut Deserializer<'gil> {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        match self.next()? {
+            Some(obj) => {
+                let (key, value): (PyObject, PyObject) = obj.extract(self.py)?;
+                self.pending_value = Some(value);
+                let mut deserializer = Deserializer::new(self.py, key);
+                seed.deserialize(&mut deserializer).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        match self.pending_value.take() {
+            Some(obj) => {
+                let mut deserializer = Deserializer::new(self.py, obj);
+                seed.deserialize(&mut deserializer)
+            }
+            None => Err(Error::value_error(
+                self.py,
+                "no value for MapAccess::next_value_seed to pick up",
+            )),
+        }
+    }
+}
+
+impl<'de, 'a, 'gil> de::EnumAccess<'de> for &'a mut Deserializer<'gil> {
+    type Error = Error;
+    type Variant = Deserializer<'gil>;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        if self.extract::<String>().is_ok() {
+            // a string for unit enum variants.
+            let name = seed.deserialize(&mut *self)?;
+            Ok((name, Deserializer::new(self.py, self.py.None())))
+        } else {
+            // a dict for complex enum variants.
+            let dict: PyDict = self.extract()?;
+            let items: Vec<(PyObject, PyObject)> = dict.items(self.py);
+            if items.len() != 1 {
+                let repr = self.obj.repr(self.py)?;
+                let repr = repr.to_string_lossy(self.py);
+                let msg = format!("dict for enum should only contain 1 item: {}", repr);
+                return Err(Error::value_error(self.py, msg));
+            }
+            let (key, value) = items.into_iter().next().unwrap();
+            let name = seed.deserialize(&mut Deserializer::new(self.py, key))?;
+            Ok((name, Deserializer::new(self.py, value)))
+        }
+    }
+}
+
+impl<'de, 'gil> de::VariantAccess<'de> for Deserializer<'gil> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<()> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(mut self, seed: T) -> Result<T::Value>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut self)
+    }
+
+    fn tuple_variant<V>(mut self, _len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        de::Deserializer::deserialize_seq(&mut self, visitor)
+    }
+
+    fn struct_variant<V>(mut self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        de::Deserializer::deserialize_map(&mut self, visitor)
+    }
+}

--- a/src/serde/error.rs
+++ b/src/serde/error.rs
@@ -1,0 +1,69 @@
+use crate::exc;
+use crate::ObjectProtocol;
+use crate::PyErr;
+use crate::Python;
+use serde::{de, ser};
+use std::fmt;
+
+/// Error type used by serialization.
+pub struct Error(PyErr);
+
+impl Error {
+    /// Construct a `ValueError` from a message.
+    pub(crate) fn value_error(py: Python, msg: impl ToString) -> Self {
+        PyErr::new::<exc::ValueError, _>(py, msg.to_string()).into()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let repr = self
+            .0
+            .pvalue
+            .as_ref()
+            .unwrap_or_else(|| &self.0.ptype)
+            .repr(py)
+            .map(|s| s.to_string_lossy(py).to_string())
+            .unwrap_or_else(|_| "<error in repr>".into());
+        write!(f, "{}", repr)?;
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl From<PyErr> for Error {
+    fn from(err: PyErr) -> Self {
+        Self(err)
+    }
+}
+
+impl From<Error> for PyErr {
+    fn from(error: Error) -> Self {
+        error.0
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl ser::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        Self::value_error(py, msg)
+    }
+}
+
+impl de::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        Self::value_error(py, msg)
+    }
+}

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,0 +1,16 @@
+//! `serde` integration.
+//! - `to_py_object` converts a Rust value to a Python object.
+//! - `from_py_object` converts a Python object back to a Rust value.
+//!
+//! Requires the `serde-convert` feature.
+
+mod de;
+mod error;
+mod ser;
+
+#[cfg(test)]
+mod tests;
+
+pub use de::from_py_object;
+pub use error::Error;
+pub use ser::to_py_object;

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -1,0 +1,398 @@
+use super::Error;
+use crate::PyBytes;
+use crate::PyDict;
+use crate::PyObject;
+use crate::PyResult;
+use crate::PyTuple;
+use crate::Python;
+use crate::PythonObject;
+use crate::ToPyObject;
+use serde::{ser, Serialize};
+use std::fmt;
+use std::marker::PhantomData;
+
+/// Serialize into Python object.
+pub fn to_py_object<T>(py: Python, value: &T) -> PyResult<PyObject>
+where
+    T: Serialize,
+{
+    let serializer = Serializer { py };
+    value.serialize(&serializer).map_err(Into::into)
+}
+
+// ------- Serializer Types -------
+
+type Result<T> = std::result::Result<T, Error>;
+
+struct Serializer<'a> {
+    py: Python<'a>,
+}
+
+trait PyCollectItems {
+    fn collect_items(py: Python, items: &[PyObject]) -> Result<PyObject>;
+}
+
+trait PyBuildVariant {
+    fn build_variant(&self, py: Python, obj: PyObject) -> Result<PyObject>;
+}
+
+struct PyItems<'a, C, V> {
+    py: Python<'a>,
+    items: Vec<PyObject>,
+    collector: PhantomData<C>,
+    variant: V,
+}
+
+impl<'a, C, V> PyItems<'a, C, V> {
+    fn new(py: Python<'a>, variant: V) -> Self {
+        Self {
+            py,
+            items: Default::default(),
+            collector: PhantomData,
+            variant,
+        }
+    }
+}
+
+impl<'a, C, V> PyItems<'a, C, V>
+where
+    C: PyCollectItems,
+    V: PyBuildVariant,
+{
+    fn collect(&self) -> Result<PyObject> {
+        let obj = C::collect_items(self.py, &self.items)?;
+        self.variant.build_variant(self.py, obj)
+    }
+}
+
+impl PyBuildVariant for &'static str {
+    fn build_variant(&self, py: Python, obj: PyObject) -> Result<PyObject> {
+        enum_variant(py, self, obj)
+    }
+}
+
+impl PyBuildVariant for () {
+    fn build_variant(&self, _py: Python, obj: PyObject) -> Result<PyObject> {
+        Ok(obj)
+    }
+}
+
+struct BuildList;
+struct BuildTuple;
+struct BuildDict;
+
+impl PyCollectItems for BuildList {
+    fn collect_items(py: Python, items: &[PyObject]) -> Result<PyObject> {
+        Ok(items.to_py_object(py).into_object())
+    }
+}
+
+impl PyCollectItems for BuildTuple {
+    fn collect_items(py: Python, items: &[PyObject]) -> Result<PyObject> {
+        Ok(PyTuple::new(py, items).into_object())
+    }
+}
+
+impl PyCollectItems for BuildDict {
+    fn collect_items(py: Python, items: &[PyObject]) -> Result<PyObject> {
+        let dict = PyDict::new(py);
+        for chunk in items.chunks(2) {
+            if let [key, value] = chunk {
+                dict.set_item(py, key, value)?;
+            }
+        }
+        Ok(dict.into_object())
+    }
+}
+
+// ------- Serde APIs -------
+
+impl<'a> Serializer<'a> {
+    fn serialize<T: ToPyObject>(&self, obj: T) -> Result<PyObject> {
+        Ok(obj.into_py_object(self.py).into_object())
+    }
+
+    fn to_object<T: Serialize + ?Sized>(py: Python, value: &T) -> Result<PyObject> {
+        let serializer = Serializer { py };
+        value.serialize(&serializer)
+    }
+}
+
+impl<'a, 'b> ser::Serializer for &'a Serializer<'b> {
+    type Ok = PyObject;
+    type Error = Error;
+
+    type SerializeSeq = PyItems<'b, BuildList, ()>;
+    type SerializeTuple = PyItems<'b, BuildTuple, ()>;
+    type SerializeTupleStruct = PyItems<'b, BuildTuple, ()>;
+    type SerializeTupleVariant = PyItems<'b, BuildTuple, &'static str>;
+    type SerializeMap = PyItems<'b, BuildDict, ()>;
+    type SerializeStruct = PyItems<'b, BuildDict, ()>;
+    type SerializeStructVariant = PyItems<'b, BuildDict, &'static str>;
+
+    fn serialize_bool(self, v: bool) -> Result<PyObject> {
+        self.serialize(v)
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<PyObject> {
+        self.serialize(v)
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<PyObject> {
+        self.serialize(v)
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<PyObject> {
+        self.serialize(v)
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<PyObject> {
+        self.serialize(v)
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<PyObject> {
+        self.serialize(v)
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<PyObject> {
+        self.serialize(v)
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<PyObject> {
+        self.serialize(v)
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<PyObject> {
+        self.serialize(v)
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<PyObject> {
+        self.serialize(v)
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<PyObject> {
+        self.serialize(v)
+    }
+
+    fn serialize_char(self, v: char) -> Result<PyObject> {
+        self.serialize_str(&v.to_string())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<PyObject> {
+        if cfg!(feature = "python2-sys") {
+            // Use the 'str' (aka. 'bytes') type consistently on Python 2.
+            Ok(PyBytes::new(self.py, v.as_bytes()).into_object())
+        } else {
+            Ok(v.to_py_object(self.py).into_object())
+        }
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<PyObject> {
+        Ok(PyBytes::new(self.py, v).into_object())
+    }
+
+    fn serialize_none(self) -> Result<PyObject> {
+        Ok(self.py.None())
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<PyObject>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<PyObject> {
+        self.serialize_none()
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<PyObject> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<PyObject> {
+        self.serialize_str(variant)
+    }
+
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<PyObject>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<PyObject>
+    where
+        T: ?Sized + Serialize,
+    {
+        let value = value.serialize(self)?;
+        enum_variant(self.py, variant, value)
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Ok(Self::SerializeSeq::new(self.py, ()))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        Ok(Self::SerializeTuple::new(self.py, ()))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        Ok(Self::SerializeTupleStruct::new(self.py, ()))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Ok(Self::SerializeTupleVariant::new(self.py, variant))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Ok(Self::SerializeMap::new(self.py, ()))
+    }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Ok(Self::SerializeStruct::new(self.py, ()))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Ok(Self::SerializeStructVariant::new(self.py, variant))
+    }
+}
+
+macro_rules! impl_seq {
+    ($trait: ty,  $name: tt) => {
+        impl<C, V> $trait for PyItems<'_, C, V>
+        where
+            C: PyCollectItems,
+            V: PyBuildVariant,
+        {
+            type Ok = PyObject;
+            type Error = Error;
+
+            fn $name<T>(&mut self, value: &T) -> Result<()>
+            where
+                T: ?Sized + Serialize,
+            {
+                let obj = Serializer::to_object(self.py, value)?;
+                self.items.push(obj);
+                Ok(())
+            }
+
+            fn end(self) -> Result<PyObject> {
+                self.collect()
+            }
+        }
+    };
+}
+
+impl_seq!(ser::SerializeSeq, serialize_element);
+impl_seq!(ser::SerializeTuple, serialize_element);
+impl_seq!(ser::SerializeTupleStruct, serialize_field);
+impl_seq!(ser::SerializeTupleVariant, serialize_field);
+
+impl<V> ser::SerializeMap for PyItems<'_, BuildDict, V>
+where
+    V: PyBuildVariant,
+{
+    type Ok = PyObject;
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let obj = Serializer::to_object(self.py, key)?;
+        self.items.push(obj);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let obj = Serializer::to_object(self.py, value)?;
+        self.items.push(obj);
+        Ok(())
+    }
+
+    fn end(self) -> Result<PyObject> {
+        self.collect()
+    }
+}
+
+impl<V> ser::SerializeStruct for PyItems<'_, BuildDict, V>
+where
+    V: PyBuildVariant,
+{
+    type Ok = PyObject;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let key = Serializer::to_object(self.py, key)?;
+        let value = Serializer::to_object(self.py, value)?;
+        self.items.push(key);
+        self.items.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<PyObject> {
+        self.collect()
+    }
+}
+
+impl<V> ser::SerializeStructVariant for PyItems<'_, BuildDict, V>
+where
+    V: PyBuildVariant,
+{
+    type Ok = PyObject;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        ser::SerializeStruct::serialize_field(self, key, value)
+    }
+
+    fn end(self) -> Result<PyObject> {
+        self.collect()
+    }
+}
+
+// ------- Utilities -------
+
+/// Convert `value` to `{key: value}` to represent an enum variant.
+fn enum_variant(py: Python, key: &'static str, value: PyObject) -> Result<PyObject> {
+    let dict = PyDict::new(py);
+    dict.set_item(py, key, value)?;
+    Ok(dict.into_object())
+}

--- a/src/serde/tests.rs
+++ b/src/serde/tests.rs
@@ -1,0 +1,116 @@
+use crate::Python;
+use crate::PyClone;
+use ::serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
+use serde_cbor::Value;
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+#[test]
+fn test_serde_basic_types() {
+    check_serde_round_trip(&42);
+    check_serde_round_trip(&Some(true));
+    check_serde_round_trip(&false);
+    check_serde_round_trip(&"abc".to_string());
+    check_serde_round_trip(&b"abc".to_vec());
+    check_serde_round_trip(&(1, (), Some(false), 3));
+    check_serde_round_trip(&vec![1, 2, 3]);
+    check_serde_round_trip(&());
+    check_serde_round_trip(&ByteBuf::from(b"abc".to_vec()));
+}
+
+#[test]
+fn test_serde_basic_structs() {
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    struct S;
+
+    check_serde_round_trip(&S);
+
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    struct A {
+        i: i64,
+        s: String,
+        u: S,
+        e: (),
+        t: (bool, (u64, f32)),
+        v: Vec<Option<bool>>,
+        m: HashMap<u64, String>,
+        #[serde(with = "serde_bytes")]
+        b: Vec<u8>,
+    }
+
+    let a = A {
+        i: i64::MIN,
+        s: "foo".to_string(),
+        u: S,
+        e: (),
+        t: (true, (u64::MAX, -2.0)),
+        v: vec![Some(true), None, Some(false)],
+        m: example_hashmap(),
+        b: b"abcdef".to_vec(),
+    };
+
+    check_serde_round_trip(&a);
+}
+
+#[test]
+fn test_serde_nested_structs() {
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    struct A(String, usize);
+
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    struct B(Option<Box<A>>, Option<Box<A>>);
+
+    let b = B(None, Some(Box::new(A("abc".to_string(), 42))));
+    check_serde_round_trip(&b);
+}
+
+#[test]
+fn test_serde_enums() {
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    enum E {
+        A,
+        B(bool, bool),
+        C { x: u8, y: Option<i8> },
+        D(Option<Box<E>>),
+    }
+
+    let values = [
+        E::A,
+        E::B(true, false),
+        E::C { x: 42, y: None },
+        E::D(None),
+        E::D(Some(Box::new(E::B(false, true)))),
+    ];
+
+    for value in &values {
+        check_serde_round_trip(value);
+    }
+}
+
+fn example_hashmap() -> HashMap<u64, String> {
+    let mut m = HashMap::new();
+    for i in 1..10 {
+        m.insert(i, i.to_string());
+    }
+    m
+}
+
+fn check_serde_round_trip<S>(value: &S)
+where
+    S: Serialize + PartialEq + Debug,
+    for<'de> S: Deserialize<'de>,
+{
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let obj = super::to_py_object(py, &value).unwrap();
+
+    let other: S = super::from_py_object(py, obj.clone_ref(py)).unwrap();
+    assert_eq!(value, &other);
+
+    // Try deserializing into a dynamic type.
+    // This exercises the `deserialize_any` code path.
+    let dynamic_value: Value = super::from_py_object(py, obj).unwrap();
+    let another: S = serde_cbor::value::from_value(dynamic_value).unwrap();
+    assert_eq!(value, &another);
+}


### PR DESCRIPTION
Converts between serde types and PyObject. This can make FromPyObject/
ToPyObject implementations easier.