### PR TITLE
Add Python 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 env:
   - RUST_VERSION=1.32.0
   - RUST_VERSION=stable

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Python is licensed under the [Python License](https://docs.python.org/2/license.
 
 Supported Python versions:
 * Python 2.7
-* Python 3.3 to 3.8
+* Python 3.3 to 3.9
 
 Requires Rust 1.32.0 or later.
 

--- a/python3-sys/Cargo.toml
+++ b/python3-sys/Cargo.toml
@@ -71,6 +71,7 @@ python-3-5 = []
 python-3-6 = []
 python-3-7 = []
 python-3-8 = []
+python-3-9 = []
 
 # Restrict to PEP-384 stable ABI
 pep-384 = []

--- a/python3-sys/src/ceval.rs
+++ b/python3-sys/src/ceval.rs
@@ -5,6 +5,7 @@ use crate::pystate::PyThreadState;
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
+    #[deprecated(since = "0.5.2", note = "Deprecated since Python 3.9")]
     pub fn PyEval_CallObjectWithKeywords(
         callable: *mut PyObject,
         obj: *mut PyObject,
@@ -13,17 +14,21 @@ extern "C" {
 }
 
 #[inline]
+#[deprecated(since = "0.5.2", note = "Deprecated since Python 3.9")]
 pub unsafe fn PyEval_CallObject(callable: *mut PyObject, arg: *mut PyObject) -> *mut PyObject {
+    #[allow(deprecated)]
     PyEval_CallObjectWithKeywords(callable, arg, core::ptr::null_mut())
 }
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
+    #[deprecated(since = "0.5.2", note = "Deprecated since Python 3.9")]
     pub fn PyEval_CallFunction(
         callable: *mut PyObject,
         format: *const c_char,
         ...
     ) -> *mut PyObject;
+    #[deprecated(since = "0.5.2", note = "Deprecated since Python 3.9")]
     pub fn PyEval_CallMethod(
         obj: *mut PyObject,
         name: *const c_char,
@@ -42,11 +47,16 @@ extern "C" {
     pub fn Py_SetRecursionLimit(arg1: c_int) -> ();
     pub fn Py_GetRecursionLimit() -> c_int;
 
-    fn _Py_CheckRecursiveCall(_where: *mut c_char) -> c_int;
-    static mut _Py_CheckRecursionLimit: c_int;
+    //fn _Py_CheckRecursiveCall(_where: *mut c_char) -> c_int;
+    //static mut _Py_CheckRecursionLimit: c_int;
+
+    #[cfg(Py_3_9)]
+    pub fn Py_EnterRecursiveCall(_where: *const c_char) -> c_int;
+    #[cfg(Py_3_9)]
+    pub fn Py_LeaveRecursiveCall() -> c_void;
 }
 
-// TODO: Py_EnterRecursiveCall etc.
+// TODO: Py_EnterRecursiveCall for Python <3.9
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/python3-sys/src/compile.rs
+++ b/python3-sys/src/compile.rs
@@ -75,3 +75,5 @@ pub const Py_file_input: c_int = 257;
 pub const Py_eval_input: c_int = 258;
 #[cfg(Py_3_8)]
 pub const Py_func_type_input: c_int = 345;
+#[cfg(Py_3_9)]
+pub const Py_fstring_input: c_int = 800;

--- a/python3-sys/src/frameobject.rs
+++ b/python3-sys/src/frameobject.rs
@@ -4,6 +4,7 @@ use crate::code::{PyCodeObject, CO_MAXBLOCKS};
 use crate::object::*;
 use crate::pystate::PyThreadState;
 
+#[cfg(not(Py_LIMITED_API))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyTryBlock {
@@ -12,6 +13,10 @@ pub struct PyTryBlock {
     pub b_level: c_int,
 }
 
+#[cfg(Py_LIMITED_API)]
+pub enum PyFrameObject {}
+
+#[cfg(not(Py_LIMITED_API))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyFrameObject {
@@ -60,16 +65,19 @@ pub struct PyFrameObject {
     pub f_localsplus: [*mut PyObject; 1], /* locals+stack, dynamically sized */
 }
 
+#[cfg(not(Py_LIMITED_API))]
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub static mut PyFrame_Type: PyTypeObject;
 }
 
+#[cfg(not(Py_LIMITED_API))]
 #[inline]
 pub unsafe fn PyFrame_Check(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyFrame_Type) as c_int
 }
 
+#[cfg(not(Py_LIMITED_API))]
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyFrame_New(
@@ -92,6 +100,14 @@ extern "C" {
     pub fn PyFrame_FastToLocalsWithError(f: *mut PyFrameObject) -> c_int;
     pub fn PyFrame_FastToLocals(f: *mut PyFrameObject) -> ();
 
+    #[cfg(not(Py_3_9))]
     pub fn PyFrame_ClearFreeList() -> c_int;
+}
+
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
     pub fn PyFrame_GetLineNumber(f: *mut PyFrameObject) -> c_int;
+
+    #[cfg(Py_3_9)]
+    pub fn PyFrame_GetCode(frame: *mut PyFrameObject) -> *mut PyCodeObject;
 }

--- a/python3-sys/src/import.rs
+++ b/python3-sys/src/import.rs
@@ -62,11 +62,10 @@ extern "C" {
     pub fn PyImport_GetImporter(path: *mut PyObject) -> *mut PyObject;
     pub fn PyImport_Import(name: *mut PyObject) -> *mut PyObject;
     pub fn PyImport_ReloadModule(m: *mut PyObject) -> *mut PyObject;
+    #[cfg(not(Py_3_9))]
     pub fn PyImport_Cleanup() -> ();
     pub fn PyImport_ImportFrozenModuleObject(name: *mut PyObject) -> c_int;
     pub fn PyImport_ImportFrozenModule(name: *const c_char) -> c_int;
-
-    // pub static mut PyNullImporter_Type: PyTypeObject; -- does not actually exist in shared library
 
     pub fn PyImport_AppendInittab(
         name: *const c_char,
@@ -101,7 +100,7 @@ extern "C" {
 
     #[cfg(not(Py_3_7))]
     pub fn _PyImport_FindBuiltin(name: *const c_char) -> *mut PyObject;
-    #[cfg(Py_3_7)]
+    #[cfg(all(Py_3_7, not(Py_3_9)))]
     pub fn _PyImport_FindBuiltin(name: *const c_char, modules: *mut PyObject) -> *mut PyObject;
 
     pub fn _PyImport_FindExtensionObject(
@@ -109,7 +108,7 @@ extern "C" {
         filename: *mut PyObject,
     ) -> *mut PyObject;
 
-    #[cfg(Py_3_7)]
+    #[cfg(all(Py_3_7, not(Py_3_9)))]
     pub fn _PyImport_FindExtensionObjectEx(
         name: *mut PyObject,
         filename: *mut PyObject,

--- a/python3-sys/src/initconfig.rs
+++ b/python3-sys/src/initconfig.rs
@@ -2,6 +2,8 @@
 
 use crate::pyport::Py_ssize_t;
 use libc::{c_char, c_int, c_ulong, wchar_t};
+#[cfg(Py_3_9)]
+use libc::c_void;
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -102,9 +104,12 @@ pub struct PyConfig {
     pub use_hash_seed: c_int,
     pub hash_seed: c_ulong,
     pub faulthandler: c_int,
+    #[cfg(Py_3_9)]
+    pub _use_peg_parser: c_int,
     pub tracemalloc: c_int,
     pub import_time: c_int,
     pub show_ref_count: c_int,
+    #[cfg(not(Py_3_9))]
     pub show_alloc_count: c_int,
     pub dump_refs: c_int,
     pub malloc_stats: c_int,
@@ -144,12 +149,18 @@ pub struct PyConfig {
     pub base_prefix: *mut wchar_t,
     pub exec_prefix: *mut wchar_t,
     pub base_exec_prefix: *mut wchar_t,
+    #[cfg(Py_3_9)]
+    pub platlibdir: *mut wchar_t,
     pub skip_source_first_line: c_int,
     pub run_command: *mut wchar_t,
     pub run_module: *mut wchar_t,
     pub run_filename: *mut wchar_t,
     pub _install_importlib: c_int,
     pub _init_main: c_int,
+    #[cfg(Py_3_9)]
+    pub _isolated_interpreter: c_int,
+    #[cfg(Py_3_9)]
+    pub _orig_argv: PyWideStringList,
 }
 
 impl Default for PyConfig {
@@ -190,4 +201,7 @@ extern "C" {
         length: Py_ssize_t,
         items: *mut *mut wchar_t,
     ) -> PyStatus;
+
+    #[cfg(Py_3_9)]
+    pub fn Py_GetArgcArgv(argc: *mut c_int, argv: *mut *mut *mut wchar_t) -> c_void;
 }

--- a/python3-sys/src/lib.rs
+++ b/python3-sys/src/lib.rs
@@ -277,13 +277,7 @@ mod fileutils;
 // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 pub mod structmember;
 
-#[cfg(not(Py_LIMITED_API))]
 pub mod frameobject;
-
-#[cfg(Py_LIMITED_API)]
-pub mod frameobject {
-    pub enum PyFrameObject {}
-}
 
 mod marshal;
 

--- a/python3-sys/src/methodobject.rs
+++ b/python3-sys/src/methodobject.rs
@@ -45,6 +45,7 @@ pub type _PyCFunctionFastWithKeywords = unsafe extern "C" fn(
     kwnames: *mut PyObject,
 ) -> *mut PyObject;
 
+#[cfg(not(Py_3_9))]
 pub type PyNoArgsFunction = unsafe extern "C" fn(slf: *mut PyObject) -> *mut PyObject;
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
@@ -52,6 +53,7 @@ extern "C" {
     pub fn PyCFunction_GetFunction(f: *mut PyObject) -> Option<PyCFunction>;
     pub fn PyCFunction_GetSelf(f: *mut PyObject) -> *mut PyObject;
     pub fn PyCFunction_GetFlags(f: *mut PyObject) -> c_int;
+    #[deprecated(since = "0.5.2", note = "Deprecated since Python 3.9")]
     pub fn PyCFunction_Call(
         f: *mut PyObject,
         args: *mut PyObject,
@@ -92,6 +94,14 @@ extern "C" {
         arg2: *mut PyObject,
         arg3: *mut PyObject,
     ) -> *mut PyObject;
+    
+    #[cfg(Py_3_9)]
+    pub fn PyCMethod_New(
+        arg1: *mut PyMethodDef,
+        arg2: *mut PyObject,
+        arg3: *mut PyObject,
+        arg4: *mut PyTypeObject,
+    ) -> *mut PyObject;
 }
 
 /* Flag passed to newmethodobject */
@@ -115,8 +125,14 @@ slot like sq_contains. */
 pub const METH_COEXIST: c_int = 0x0040;
 
 #[cfg(all(Py_3_6, not(Py_LIMITED_API)))]
-pub const METHOD_FASTCALL: c_int = 0x0080;
+pub const METH_FASTCALL: c_int = 0x0080;
 
+// METH_STACKLESS: This bit is preserved for Stackless Python
+
+#[cfg(all(Py_3_9))]
+pub const METH_METHOD: c_int = 0x0200;
+
+#[cfg(not(Py_3_9))]
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyCFunction_ClearFreeList() -> c_int;

--- a/python3-sys/src/modsupport.rs
+++ b/python3-sys/src/modsupport.rs
@@ -2,6 +2,8 @@ use libc::{c_char, c_int, c_long};
 
 #[cfg(Py_3_5)]
 use crate::methodobject::PyMethodDef;
+#[cfg(Py_3_9)]
+use crate::object::PyTypeObject;
 use crate::moduleobject::PyModuleDef;
 use crate::object::PyObject;
 use crate::pyport::Py_ssize_t;
@@ -42,6 +44,8 @@ extern "C" {
         arg2: *const c_char,
         arg3: *const c_char,
     ) -> c_int;
+    #[cfg(Py_3_9)]
+    pub fn PyModule_AddType(module: *mut PyObject, ty: *mut PyTypeObject) -> c_int;
     #[cfg(Py_3_5)]
     pub fn PyModule_SetDocString(arg1: *mut PyObject, arg2: *const c_char) -> c_int;
     #[cfg(Py_3_5)]

--- a/python3-sys/src/objectabstract.rs
+++ b/python3-sys/src/objectabstract.rs
@@ -16,6 +16,9 @@ pub unsafe fn PyObject_DelAttr(o: *mut PyObject, attr_name: *mut PyObject) -> c_
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
+    #[cfg(Py_3_9)]
+    pub fn PyObject_CallNoArgs(func: *mut PyObject) -> *mut PyObject;
+
     pub fn PyObject_Call(
         callable: *mut PyObject,
         args: *mut PyObject,
@@ -80,7 +83,7 @@ extern "C" {
     ) -> c_int;
 }
 
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(all(not(Py_LIMITED_API), not(Py_3_9)))]
 #[inline]
 pub unsafe fn PyObject_CheckBuffer(o: *mut PyObject) -> c_int {
     let tp_as_buffer = (*(*o).ob_type).tp_as_buffer;
@@ -91,6 +94,8 @@ pub unsafe fn PyObject_CheckBuffer(o: *mut PyObject) -> c_int {
 #[cfg(not(Py_LIMITED_API))]
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
+    #[cfg(Py_3_9)]
+    pub fn PyObject_CheckBuffer(o: *mut PyObject) -> c_int;
     pub fn PyObject_GetBuffer(obj: *mut PyObject, view: *mut Py_buffer, flags: c_int) -> c_int;
     pub fn PyBuffer_GetPointer(view: *mut Py_buffer, indices: *mut Py_ssize_t) -> *mut c_void;
     pub fn PyBuffer_ToContiguous(
@@ -173,7 +178,8 @@ extern "C" {
     pub fn PyNumber_Or(o1: *mut PyObject, o2: *mut PyObject) -> *mut PyObject;
 }
 
-#[cfg(not(Py_LIMITED_API))]
+// Note: Py 3.8 has PyIndex_Check as a function, prior to that it was only availabe as a macro
+#[cfg(all(not(Py_LIMITED_API), not(Py_3_8)))]
 #[inline]
 pub unsafe fn PyIndex_Check(o: *mut PyObject) -> c_int {
     let tp_as_number = (*(*o).ob_type).tp_as_number;
@@ -182,8 +188,7 @@ pub unsafe fn PyIndex_Check(o: *mut PyObject) -> c_int {
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
-    // Note: without Py_LIMITED_API, PyIndex_Check is a macro instead
-    #[cfg(all(Py_3_8, Py_LIMITED_API))]
+    #[cfg(Py_3_8)]
     pub fn PyIndex_Check(o: *mut PyObject) -> c_int;
 
     pub fn PyNumber_Index(o: *mut PyObject) -> *mut PyObject;

--- a/python3-sys/src/pystate.rs
+++ b/python3-sys/src/pystate.rs
@@ -1,6 +1,8 @@
 use libc;
 
 use crate::moduleobject::PyModuleDef;
+#[cfg(Py_3_9)]
+use crate::frameobject::PyFrameObject;
 use crate::object::PyObject;
 
 #[cfg(Py_3_6)]
@@ -14,6 +16,8 @@ extern "C" {
     pub fn PyInterpreterState_New() -> *mut PyInterpreterState;
     pub fn PyInterpreterState_Clear(arg1: *mut PyInterpreterState) -> ();
     pub fn PyInterpreterState_Delete(arg1: *mut PyInterpreterState) -> ();
+    #[cfg(Py_3_9)]
+    pub fn PyInterpreterState_Get() -> *mut PyInterpreterState;
     #[cfg(Py_3_8)]
     pub fn PyInterpreterState_GetDict(arg1: *mut PyInterpreterState) -> *mut PyObject;
     #[cfg(Py_3_7)]
@@ -34,6 +38,12 @@ extern "C" {
     pub fn PyThreadState_SetAsyncExc(arg1: libc::c_long, arg2: *mut PyObject) -> libc::c_int;
     #[cfg(Py_3_7)]
     pub fn PyThreadState_SetAsyncExc(arg1: libc::c_ulong, arg2: *mut PyObject) -> libc::c_int;
+    #[cfg(Py_3_9)]
+    pub fn PyThreadState_GetInterpreter(tstate: *mut PyThreadState) -> *mut PyInterpreterState;
+    #[cfg(Py_3_9)]
+    pub fn PyThreadState_GetFrame(tstate: *mut PyThreadState) -> *mut PyFrameObject;
+    #[cfg(Py_3_9)]
+    pub fn PyThreadState_GetID(tstate: *mut PyThreadState) -> u64;
 }
 
 #[repr(C)]

--- a/python3-sys/src/pythonrun.rs
+++ b/python3-sys/src/pythonrun.rs
@@ -120,23 +120,29 @@ pub enum symtable {}
 pub enum _node {}
 
 #[inline]
+#[deprecated(since = "0.5.2", note = "Deprecated since Python 3.9")]
 pub unsafe fn PyParser_SimpleParseString(s: *const c_char, b: c_int) -> *mut _node {
+    #[allow(deprecated)]
     PyParser_SimpleParseStringFlags(s, b, 0)
 }
 
 #[cfg(not(Py_LIMITED_API))]
 #[inline]
+#[deprecated(since = "0.5.2", note = "Deprecated since Python 3.9")]
 pub unsafe fn PyParser_SimpleParseFile(fp: *mut FILE, s: *const c_char, b: c_int) -> *mut _node {
+    #[allow(deprecated)]
     PyParser_SimpleParseFileFlags(fp, s, b, 0)
 }
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
+    #[deprecated(since = "0.5.2", note = "Deprecated since Python 3.9")]
     pub fn PyParser_SimpleParseStringFlags(
         arg1: *const c_char,
         arg2: c_int,
         arg3: c_int,
     ) -> *mut _node;
+    #[deprecated(since = "0.5.2", note = "Deprecated since Python 3.9")]
     pub fn PyParser_SimpleParseStringFlagsFilename(
         arg1: *const c_char,
         arg2: *const c_char,
@@ -144,6 +150,7 @@ extern "C" {
         arg4: c_int,
     ) -> *mut _node;
     #[cfg(not(Py_LIMITED_API))]
+    #[deprecated(since = "0.5.2", note = "Deprecated since Python 3.9")]
     pub fn PyParser_SimpleParseFileFlags(
         arg1: *mut FILE,
         arg2: *const c_char,

--- a/python3-sys/src/tupleobject.rs
+++ b/python3-sys/src/tupleobject.rs
@@ -38,6 +38,7 @@ extern "C" {
         arg3: Py_ssize_t,
     ) -> *mut PyObject;
     pub fn PyTuple_Pack(arg1: Py_ssize_t, ...) -> *mut PyObject;
+    #[cfg(not(Py_3_9))]
     pub fn PyTuple_ClearFreeList() -> c_int;
 }
 

--- a/python3-sys/src/unicodeobject.rs
+++ b/python3-sys/src/unicodeobject.rs
@@ -121,6 +121,7 @@ extern "C" {
         size: *mut Py_ssize_t,
     ) -> *mut wchar_t;
     pub fn PyUnicode_FromOrdinal(ordinal: c_int) -> *mut PyObject;
+    #[cfg(not(Py_3_9))]
     pub fn PyUnicode_ClearFreeList() -> c_int;
     #[cfg(not(Py_LIMITED_API))]
     pub fn PyUnicode_AsUTF8AndSize(unicode: *mut PyObject, size: *mut Py_ssize_t) -> *const c_char;


### PR DESCRIPTION
As usual with new Python releases, I diffed the 3.8.0 Python headers against the 3.9.0 Python headers and manually made these adjustments to python3-sys.

While rust-cpython could be compiled against Python 3.9 without these changes, there were some breaking changes to the headers:
 * some macros like `PyObject_IS_GC` or `PyObject_GET_WEAKREFS_LISTPTR` were replaced with functions
 * some functions were removed from the API
 * `PyConfig` had breaking changes to the struct layout