### PR TITLE
Avoid abort() if the Python function never returns (thread exit)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ paste = "0.1"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
+rustversion = "1.0"
 serde_bytes = { version = "0.11" }
 serde_cbor = { version = "0.11" }
 

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,13 @@ NIGHTLY := 0
 endif
 endif
 
+FEATURES := serde-convert
+
 ifeq ($(PY),2)
-FEATURES := python27-sys
+FEATURES := $(FEATURES) python27-sys
 endif
 ifeq ($(PY),3)
-FEATURES := python3-sys
+FEATURES := $(FEATURES) python3-sys
 ifdef PEP384
 export PEP384=1
 FEATURES := $(FEATURES) pep-384
@@ -45,14 +47,14 @@ build: src/py_class/py_class_impl2.rs src/py_class/py_class_impl3.rs python27-sy
 	cargo build $(CARGO_FLAGS)
 
 test: build
-	cargo test --features serde-convert $(CARGO_FLAGS)
+	cargo test $(CARGO_FLAGS)
 ifeq ($(NIGHTLY),1)
 # ast-json output is only supported on nightly
 	python$(PY) tests/check_symbols.py
 endif
 
 doc: build
-	cargo doc --no-deps --features serde-convert $(CARGO_FLAGS)
+	cargo doc --no-deps $(CARGO_FLAGS)
 
 extensions: build
 	make -C extensions/tests PY=$(PY)

--- a/src/function.rs
+++ b/src/function.rs
@@ -207,13 +207,12 @@ where
     }
 }
 
-pub unsafe fn handle_callback<F, T, C>(location: &str, _c: C, f: F) -> C::R
+pub unsafe fn handle_callback<F, T, C>(_location: &str, _c: C, f: F) -> C::R
 where
     F: FnOnce(Python) -> PyResult<T>,
     F: panic::UnwindSafe,
     C: CallbackConverter<T>,
 {
-    let guard = AbortOnDrop(location);
     let ret = panic::catch_unwind(|| {
         let py = Python::assume_gil_acquired();
         match f(py) {
@@ -231,7 +230,6 @@ where
             C::error_value()
         }
     };
-    mem::forget(guard);
     ret
 }
 

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -68,7 +68,10 @@ impl<'gil> Deserializer<'gil> {
                 self.obj_iter = Some(iter);
                 self.next()
             }
-            Some(ref mut iter) => iter.next().transpose().map_err(Into::into),
+            Some(ref mut iter) => match iter.next() {
+                Some(value) => Ok(Some(value?)),
+                None => Ok(None),
+            },
         }
     }
 

--- a/src/serde/tests.rs
+++ b/src/serde/tests.rs
@@ -1,6 +1,6 @@
-use crate::Python;
 use crate::PyClone;
-use ::serde::{Deserialize, Serialize};
+use crate::Python;
+use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use serde_cbor::Value;
 use std::collections::HashMap;
@@ -40,11 +40,11 @@ fn test_serde_basic_structs() {
     }
 
     let a = A {
-        i: i64::MIN,
+        i: 0x8000000000000000u64 as i64,
         s: "foo".to_string(),
         u: S,
         e: (),
-        t: (true, (u64::MAX, -2.0)),
+        t: (true, (0xffffffffffffffffu64, -2.0)),
         v: vec![Some(true), None, Some(false)],
         m: example_hashmap(),
         b: b"abcdef".to_vec(),

--- a/tests/test_thread_exit.rs
+++ b/tests/test_thread_exit.rs
@@ -1,0 +1,53 @@
+use cpython::*;
+
+fn test_thread_exit_py(py: Python) -> PyResult<()> {
+    let m = py.import("sys")?;
+    m.add(py, "exit_thread", py_fn!(py, exit_thread()))?;
+    py.run(
+        "
+import sys, threading
+# should not abort
+threading.Thread(target=sys.exit_thread).start()
+",
+        None,
+        None,
+    )?;
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    Ok(())
+}
+
+// This test requires Rust 1.40, namely
+// https://github.com/rust-lang/rust/pull/65646.
+//
+// `pthread_exit` on Linux raises a C++ `__foced_unwind` exception to unwind
+// the stack. That exception does not inherit from C++ `std::exception` and
+// must be rethrown if caught, otherwise pthread will abort with
+// `FATAL: exception not rethrown`. On the Rust land, `catch_unwind` before
+// PR65646 will incorrectly silent that C++ exception without rethrowing,
+// breaking this test.
+//
+// Also skip nightly compilers, which might include some unstable changes
+// affecting the test.
+#[rustversion::all(since(1.40), stable)]
+#[test]
+fn test_thread_exit() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    test_thread_exit_py(py).unwrap();
+}
+
+fn exit_thread(py: Python) -> PyResult<String> {
+    #[cfg(unix)]
+    {
+        py.allow_threads(|| {
+            // Emulates PyThread_exit_thread. It can happen during Py_Finalize.
+            unsafe { libc::pthread_exit(std::ptr::null_mut()) };
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = py;
+        // pthread might not exist on this platform.
+        Ok(String::new())
+    }
+}


### PR DESCRIPTION
The AbortOnDrop is used in this pattern:

    let guard = AbortOnDrop(...);
    call_into_python(...);
    mem::forget(guard);

There is a special case that call_into_python does not return
(ex. the thread gets dropped). If that happens with pthread backend,
the `mem::forget` does not run, but `guard::drop` still runs, causing
the program to abort.

Remove AbortOnDrop to make that multi-thread case work.