### PR TITLE
Bump from paste 0.1 to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ exclude = [
     "/.cargo/config",
     "/python27-sys/**",
     "/python3-sys/**",
-    "/extensions/**"
+    "/extensions/**",
+    "/Makefile"
 ]
 build = "build.rs"
 edition = "2018"
@@ -34,7 +35,7 @@ appveyor = { repository = "dgrunwald/rust-cpython" }
 [dependencies]
 libc = "0.2"
 num-traits = "0.2"
-paste = "0.1"
+paste = "1"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This commit also adds excludes for one more file (Makefile), as that file is not useful in published crates.
