### PR TITLE
allow all visibility keywords on classes and functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,13 @@ rustflags = [
 ```
 
 For `setup.py` integration, see https://github.com/PyO3/setuptools-rust
+
+# Development
+
+To build the crate, run: `make build`
+
+To test the crate, run: `make test`
+
+Note: This crate has several files that are auto-generated using scripts. Using the Makefile ensures that these
+files are re-generated as needed.
+>>>>>>> 9ce2de8 (Add comment explaining how to regenerate)

--- a/python27-sys/src/lib.rs
+++ b/python27-sys/src/lib.rs
@@ -1,5 +1,10 @@
 #![no_std]
-#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case, unused_parens)]
+#![allow(
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    unused_parens
+)]
 
 pub use crate::boolobject::*;
 pub use crate::bufferobject::*;

--- a/python3-sys/src/initconfig.rs
+++ b/python3-sys/src/initconfig.rs
@@ -1,9 +1,9 @@
 // This entire module is Python 3.8+ and !Py_LIMITED_API only.
 
 use crate::pyport::Py_ssize_t;
-use libc::{c_char, c_int, c_ulong, wchar_t};
 #[cfg(Py_3_9)]
 use libc::c_void;
+use libc::{c_char, c_int, c_ulong, wchar_t};
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/python3-sys/src/lib.rs
+++ b/python3-sys/src/lib.rs
@@ -1,5 +1,10 @@
 #![no_std]
-#![allow(non_camel_case_types, non_snake_case, non_upper_case_globals, unused_parens)]
+#![allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_parens
+)]
 #![cfg_attr(Py_LIMITED_API, allow(unused_imports))]
 
 // old: marked with TODO

--- a/python3-sys/src/methodobject.rs
+++ b/python3-sys/src/methodobject.rs
@@ -94,7 +94,7 @@ extern "C" {
         arg2: *mut PyObject,
         arg3: *mut PyObject,
     ) -> *mut PyObject;
-    
+
     #[cfg(Py_3_9)]
     pub fn PyCMethod_New(
         arg1: *mut PyMethodDef,

--- a/python3-sys/src/modsupport.rs
+++ b/python3-sys/src/modsupport.rs
@@ -2,10 +2,10 @@ use libc::{c_char, c_int, c_long};
 
 #[cfg(Py_3_5)]
 use crate::methodobject::PyMethodDef;
-#[cfg(Py_3_9)]
-use crate::object::PyTypeObject;
 use crate::moduleobject::PyModuleDef;
 use crate::object::PyObject;
+#[cfg(Py_3_9)]
+use crate::object::PyTypeObject;
 use crate::pyport::Py_ssize_t;
 
 #[cfg_attr(windows, link(name = "pythonXY"))]

--- a/python3-sys/src/object.rs
+++ b/python3-sys/src/object.rs
@@ -723,9 +723,12 @@ extern "C" {
     #[cfg(Py_3_4)]
     pub fn PyType_GetSlot(arg1: *mut PyTypeObject, arg2: c_int) -> *mut c_void;
 
-
     #[cfg(Py_3_9)]
-    pub fn PyType_FromModuleAndSpec(arg1: *mut PyObject, arg2: *mut PyType_Spec, arg3: *mut PyObject) -> *mut PyObject;
+    pub fn PyType_FromModuleAndSpec(
+        arg1: *mut PyObject,
+        arg2: *mut PyType_Spec,
+        arg3: *mut PyObject,
+    ) -> *mut PyObject;
 
     #[cfg(Py_3_9)]
     pub fn PyType_GetModule(arg1: *mut PyTypeObject) -> *mut PyObject;

--- a/python3-sys/src/pystate.rs
+++ b/python3-sys/src/pystate.rs
@@ -1,8 +1,8 @@
 use libc;
 
-use crate::moduleobject::PyModuleDef;
 #[cfg(Py_3_9)]
 use crate::frameobject::PyFrameObject;
+use crate::moduleobject::PyModuleDef;
 use crate::object::PyObject;
 
 #[cfg(Py_3_6)]

--- a/src/py_class/py_class.rs
+++ b/src/py_class/py_class.rs
@@ -25,7 +25,9 @@ instances of that Python class from Rust.
 # Syntax
 `py_class!(pub class MyType |py| { ... })`
 
-* `pub` makes the generated Rust struct visible outside the current module. It has no effect on the visibility from Python.
+* `pub` makes the generated Rust struct visible outside the current module. It has no effect on
+the visibility from Python. You may use any Rust visibility keyword. For example, `pub(crate)`
+would also be valid.
 * `MyType` is the name of the Python class.
 * `py` is an identifier that will be made available as a variable of type `Python`
 in all function bodies.
@@ -475,14 +477,14 @@ macro_rules! py_class {
             /* props: */ { [ /* getters */ ] [ /* setters */ ] }
         }
     );
-    (pub class $class:ident |$py: ident| { $( $body:tt )* }) => (
+    ($visibility:vis class $class:ident |$py: ident| { $( $body:tt )* }) => (
         $crate::py_class_impl! {
             { $( $body )* }
             $class $py
             /* info: */ {
                 /* base_type: */ $crate::PyObject,
                 /* size: */ <$crate::PyObject as $crate::py_class::BaseObject>::size(),
-                /* class_visibility: */ {pub},
+                /* class_visibility: */ {$visibility},
                 /* gc: */ {
                     /* traverse_proc: */ None,
                     /* traverse_data: */ [ /*name*/ ]

--- a/src/py_class/py_class.rs
+++ b/src/py_class/py_class.rs
@@ -512,11 +512,11 @@ macro_rules! py_class {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! py_class_impl_item {
-    { $class:ident, $py:ident, $name:ident( $( $selfarg:tt )* )
+    { $class:ident, $py:ident, $visibility:vis, $name:ident( $( $selfarg:tt )* )
         $res_type:ty; $body:block [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]
     } => { $crate::py_coerce_item! {
         impl $class {
-            pub fn $name($( $selfarg )* $py: $crate::Python $( , $pname: $ptype )* )
+            $visibility fn $name($( $selfarg )* $py: $crate::Python $( , $pname: $ptype )* )
             -> $res_type $body
         }
     }}

--- a/src/py_class/py_class.rs
+++ b/src/py_class/py_class.rs
@@ -91,6 +91,7 @@ impl MyType {
 * The generated type implements a number of traits from the `cpython` crate.
 * The inherent `create_instance` method can create new Python objects
   given the values for the data fields.
+    - Note: Any visibility keyword on the class will also be used for this method.
 * Private accessors functions are created for the data fields.
 * All functions callable from Python are also exposed as public Rust functions.
 * To convert from `MyType` to `PyObject`, use `as_object()` or `into_object()` (from the `PythonObject` trait).
@@ -141,6 +142,7 @@ impl MyType {
 
 ## Instance methods
 `def method_name(&self, parameter-list) -> PyResult<...> { ... }`
+`pub(crate) def method_name(&self, parameter-list) -> PyResult<...> { ... }`
 
 Declares an instance method callable from Python.
 
@@ -148,9 +150,13 @@ Declares an instance method callable from Python.
   be a shared reference (`&self`).
 * For details on `parameter-list`, see the documentation of `py_argparse!()`.
 * The return type must be `PyResult<T>` for some `T` that implements `ToPyObject`.
+* Visibility of the method in Rust defaults to `pub`. You may specify a visibility keyword
+  before the `def` to change the visibility, for example, to `pub(crate)`. Changing visibility
+  in Rust does not affect visibility in Python.
 
 ## Class methods
 `@classmethod def method_name(cls, parameter-list) -> PyResult<...> { ... }`
+`@classmethod pub(crate) def method_name(cls, parameter-list) -> PyResult<...> { ... }`
 
 Declares a class method callable from Python.
 
@@ -159,14 +165,21 @@ Declares a class method callable from Python.
 * The first parameter implicitly has type `&PyType`. This type must not be explicitly specified.
 * For details on `parameter-list`, see the documentation of `py_argparse!()`.
 * The return type must be `PyResult<T>` for some `T` that implements `ToPyObject`.
+* Visibility of the method in Rust defaults to `pub`. You may specify a visibility keyword
+  before the `def` to change the visibility, for example, to `pub(crate)`. Changing visibility
+  in Rust does not affect visibility in Python.
 
 ## Static methods
 `@staticmethod def method_name(parameter-list) -> PyResult<...> { ... }`
+`@staticmethod pub(crate) def method_name(parameter-list) -> PyResult<...> { ... }`
 
 Declares a static method callable from Python.
 
 * For details on `parameter-list`, see the documentation of `py_argparse!()`.
 * The return type must be `PyResult<T>` for some `T` that implements `ToPyObject`.
+* Visibility of the method in Rust defaults to `pub`. You may specify a visibility keyword
+  before the `def` to change the visibility, for example, to `pub(crate)`. Changing visibility
+  in Rust does not affect visibility in Python.
 
 ## Properties
 `@property def property_name(&self) -> PyResult<...> { ... }`

--- a/src/py_class/py_class_impl.py
+++ b/src/py_class/py_class_impl.py
@@ -438,14 +438,14 @@ def generate_class_method(special_name=None, decoration='',
         if with_params:
             param_pattern = ', $($p:tt)+'
             impl = '''$crate::py_argparse_parse_plist_impl!{
-                py_class_impl_item { $class, $py, %s($cls: &$crate::PyType,) $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, %s($cls: &$crate::PyType,) $res_type; { $($body)* } }
                 [] ($($p)+,)
             }''' % name_use
             value = '$crate::py_argparse_parse_plist_impl!{%s {%s} [] ($($p)+,)}' \
                     % (value_macro, value_args + value_suffix)
         else:
             param_pattern = ''
-            impl = '$crate::py_class_impl_item! { $class, $py,%s($cls: &$crate::PyType,) $res_type; { $($body)* } [] }' \
+            impl = '$crate::py_class_impl_item! { $class, $py, pub, %s($cls: &$crate::PyType,) $res_type; { $($body)* } [] }' \
                 % name_use
             value = '$crate::%s!{%s []}' % (value_macro, value_args + value_suffix)
         pattern = '%s def %s ($cls:ident%s) -> $res_type:ty { $( $body:tt )* }' \
@@ -523,14 +523,14 @@ def generate_instance_method(special_name=None, decoration='',
         if with_params:
             param_pattern = ', $($p:tt)+'
             impl = '''$crate::py_argparse_parse_plist_impl!{
-                py_class_impl_item { $class, $py, %s(&$slf,) $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, %s(&$slf,) $res_type; { $($body)* } }
                 [] ($($p)+,)
             }''' % name_use
             value = '$crate::py_argparse_parse_plist_impl!{%s {%s} [] ($($p)+,)}' \
                     % (value_macro, value_args + value_suffix)
         else:
             param_pattern = ''
-            impl = '$crate::py_class_impl_item! { $class, $py, %s(&$slf,) $res_type; { $($body)* } [] }' \
+            impl = '$crate::py_class_impl_item! { $class, $py, pub, %s(&$slf,) $res_type; { $($body)* } [] }' \
                 % name_use
             value = '$crate::%s!{%s []}' % (value_macro, value_args + value_suffix)
         pattern = '%s def %s (&$slf:ident%s) -> $res_type:ty { $( $body:tt )* }' \
@@ -553,7 +553,7 @@ def static_method():
         '$(#[doc=$doc:expr])* @staticmethod def $name:ident ($($p:tt)*) -> $res_type:ty { $( $body:tt )* }',
         new_impl='''
             $crate::py_argparse_parse_plist!{
-                py_class_impl_item { $class, $py, $name() $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, $name() $res_type; { $($body)* } }
                 ($($p)*)
             }
         ''',
@@ -572,19 +572,19 @@ def static_data():
 
 def property_method():
     generate_case('$(#[doc=$doc:expr])* @property def $name:ident(&$slf:ident) -> $res_type:ty { $( $body:tt )* }',
-        new_impl='$crate::py_class_impl_item! { $class, $py, $name(&$slf,) $res_type; { $($body)* } [] }',
+        new_impl='$crate::py_class_impl_item! { $class, $py, pub, $name(&$slf,) $res_type; { $($body)* } [] }',
         new_props=([('concat!($($doc, "\\n"),*)', '$name', '$res_type')], [])
     )
     generate_case('@$name:ident.setter def $setter_name:ident(&$slf:ident, $value:ident : Option<Option<&$value_type:ty>> ) -> $res_type:ty { $( $body:tt )* }',
-        new_impl='$crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<Option<&$value_type>> = {} }] }',
+        new_impl='$crate::py_class_impl_item! { $class, $py, pub, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<Option<&$value_type>> = {} }] }',
         new_props=([], [('$name', 'Option<&$value_type>', '$setter_name')])
     )
     generate_case('@$name:ident.setter def $setter_name:ident(&$slf:ident, $value:ident : Option<&$value_type:ty> ) -> $res_type:ty { $( $body:tt )* }',
-        new_impl='$crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<&$value_type> = {} }] }',
+        new_impl='$crate::py_class_impl_item! { $class, $py, pub, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<&$value_type> = {} }] }',
         new_props=([], [('$name', '&$value_type', '$setter_name')])
     )
     generate_case('@$name:ident.setter def $setter_name:ident(&$slf:ident, $value:ident : Option<$value_type:ty> ) -> $res_type:ty { $( $body:tt )* }',
-        new_impl='$crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<$value_type> = {} }] }',
+        new_impl='$crate::py_class_impl_item! { $class, $py, pub, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<$value_type> = {} }] }',
         new_props=([], [('$name', '$value_type', '$setter_name')])
     )
 
@@ -689,7 +689,7 @@ def operator_impl(special_name, slot, args, res_type, res_conv, res_ffi_type, ad
         raise ValueError('Unsupported argument count')
     generate_case(
         pattern='def %s(&$slf:ident%s) -> $res_type:ty { $($body:tt)* }' % (special_name, arg_pattern),
-        new_impl='$crate::py_class_impl_item! { $class, $py, %s(&$slf,) $res_type; { $($body)* } [%s] }'
+        new_impl='$crate::py_class_impl_item! { $class, $py, pub, %s(&$slf,) $res_type; { $($body)* } [%s] }'
                  % (special_name, ' '.join(param_list)),
         new_slots=new_slots + list(additional_slots)
     )
@@ -707,7 +707,7 @@ def binary_numeric_operator(special_name, slot):
     generate_case(
         pattern='def %s($left:ident, $right:ident) -> $res_type:ty { $($body:tt)* }'
             % special_name,
-        new_impl='$crate::py_class_impl_item! { $class, $py, %s() $res_type; { $($body)* } ' % special_name
+        new_impl='$crate::py_class_impl_item! { $class, $py, pub, %s() $res_type; { $($body)* } ' % special_name
                 +'[ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }',
         new_slots=[(slot, '$crate::py_class_binary_numeric_slot!($class::%s)' % special_name)]
     )

--- a/src/py_class/py_class_impl.py
+++ b/src/py_class/py_class_impl.py
@@ -921,6 +921,8 @@ def main():
     print('// THIS IS A GENERATED FILE !!')
     print('//       DO NOT MODIFY      !!')
     print('// !!!!!!!!!!!!!!!!!!!!!!!!!!!')
+    print('//')
+    print('// REGENERATE USING THE MAKEFILE IN ROOT OF REPOSITORY: make build')
     print(macro_start)
     print(base_case)
     data_decl()

--- a/src/py_class/py_class_impl.py
+++ b/src/py_class/py_class_impl.py
@@ -139,7 +139,7 @@ base_case = '''
         $($imp)*
         $crate::py_coerce_item! {
             impl $class {
-                fn create_instance(py: $crate::Python $( , $data_name : $init_ty )* ) -> $crate::PyResult<$class> {
+                $($class_visibility)* fn create_instance(py: $crate::Python $( , $data_name : $init_ty )* ) -> $crate::PyResult<$class> {
                     let obj = unsafe {
                         <$class as $crate::py_class::BaseObject>::alloc(
                             py, &py.get_type::<$class>(), ( $($data_name,)* )

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -387,7 +387,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __abs__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __abs__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -417,7 +417,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __add__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __add__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -459,7 +459,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __and__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __and__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -487,13 +487,13 @@ macro_rules! py_class_impl {
             $type_slots
             /* as_number */ [
                 $( $nb_slot_name : $nb_slot_value, )*
-                nb_nonzero: $crate::py_class_unary_slot!($class::__bool__, $crate::_detail::libc::c_int, $crate::py_class::slots::BoolConverter),
+                nb_bool: $crate::py_class_unary_slot!($class::__bool__, $crate::_detail::libc::c_int, $crate::py_class::slots::BoolConverter),
             ]
             $as_sequence $as_mapping $setdelitem
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __bool__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __bool__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -521,7 +521,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __call__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __call__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -546,7 +546,7 @@ macro_rules! py_class_impl {
         /* impl: */ {
             $($imp)*
             $crate::py_argparse_parse_plist_impl!{
-                py_class_impl_item { $class, $py, __call__(&$slf,) $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, __call__(&$slf,) $res_type; { $($body)* } }
                 [] ($($p)+,)
             }
         }
@@ -586,7 +586,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : Option<&$item_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : Option<&$item_name> = {} }] }
         }
         $members $props
     }};
@@ -612,7 +612,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : &$item_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : &$item_name = {} }] }
         }
         $members $props
     }};
@@ -638,7 +638,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : $item_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : $item_name = {} }] }
         }
         $members $props
     }};
@@ -681,7 +681,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
         }
         $members $props
     }};
@@ -708,7 +708,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
         }
         $members $props
     }};
@@ -735,7 +735,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
         }
         $members $props
     }};
@@ -810,7 +810,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
         }
         $members $props
     }};
@@ -841,7 +841,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
         }
         $members $props
     }};
@@ -872,7 +872,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
         }
         $members $props
     }};
@@ -904,7 +904,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __hash__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __hash__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -934,7 +934,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -960,7 +960,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -986,7 +986,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1016,7 +1016,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1042,7 +1042,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1068,7 +1068,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1102,7 +1102,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1128,7 +1128,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1154,7 +1154,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1184,7 +1184,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1210,7 +1210,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1236,7 +1236,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1266,7 +1266,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1292,7 +1292,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1318,7 +1318,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1348,7 +1348,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1374,7 +1374,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1400,7 +1400,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1430,7 +1430,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1456,7 +1456,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1482,7 +1482,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1528,7 +1528,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __invert__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __invert__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -1558,7 +1558,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1584,7 +1584,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1610,7 +1610,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1644,7 +1644,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1670,7 +1670,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1696,7 +1696,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1726,7 +1726,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1752,7 +1752,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1778,7 +1778,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1806,7 +1806,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iter__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iter__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -1836,7 +1836,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1862,7 +1862,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1888,7 +1888,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1918,7 +1918,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1944,7 +1944,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1970,7 +1970,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -2009,7 +2009,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __len__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __len__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2043,7 +2043,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __lshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __lshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2085,7 +2085,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __mul__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __mul__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2119,7 +2119,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __neg__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __neg__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2147,7 +2147,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py,__new__($cls: &$crate::PyType,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __new__($cls: &$crate::PyType,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2172,7 +2172,7 @@ macro_rules! py_class_impl {
         /* impl: */ {
             $($imp)*
             $crate::py_argparse_parse_plist_impl!{
-                py_class_impl_item { $class, $py, __new__($cls: &$crate::PyType,) $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, __new__($cls: &$crate::PyType,) $res_type; { $($body)* } }
                 [] ($($p)+,)
             }
         }
@@ -2198,7 +2198,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __next__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __next__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2232,7 +2232,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __or__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __or__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2262,7 +2262,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __pos__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __pos__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2310,7 +2310,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __repr__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __repr__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2342,7 +2342,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} } { $op : $op_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} } { $op : $op_name = {} }] }
         }
         $members $props
     }};
@@ -2366,7 +2366,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} } { $op : $op_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} } { $op : $op_name = {} }] }
         }
         $members $props
     }};
@@ -2390,7 +2390,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} } { $op : $op_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} } { $op : $op_name = {} }] }
         }
         $members $props
     }};
@@ -2452,7 +2452,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __rshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __rshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2503,7 +2503,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} } { $value : $value_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} } { $value : $value_name = {} }] }
         }
         $members $props
     }};
@@ -2530,7 +2530,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} } { $value : $value_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} } { $value : $value_name = {} }] }
         }
         $members $props
     }};
@@ -2557,7 +2557,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} } { $value : $value_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} } { $value : $value_name = {} }] }
         }
         $members $props
     }};
@@ -2585,7 +2585,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __str__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __str__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2615,7 +2615,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __sub__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __sub__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2653,7 +2653,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __xor__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __xor__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2670,7 +2670,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, $name(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, $name(&$slf,) $res_type; { $($body)* } [] }
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
@@ -2687,7 +2687,7 @@ macro_rules! py_class_impl {
         /* impl: */ {
             $($imp)*
             $crate::py_argparse_parse_plist_impl!{
-                py_class_impl_item { $class, $py, $name(&$slf,) $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, $name(&$slf,) $res_type; { $($body)* } }
                 [] ($($p)+,)
             }
         }
@@ -2705,7 +2705,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py,$name($cls: &$crate::PyType,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, $name($cls: &$crate::PyType,) $res_type; { $($body)* } [] }
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
@@ -2722,7 +2722,7 @@ macro_rules! py_class_impl {
         /* impl: */ {
             $($imp)*
             $crate::py_argparse_parse_plist_impl!{
-                py_class_impl_item { $class, $py, $name($cls: &$crate::PyType,) $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, $name($cls: &$crate::PyType,) $res_type; { $($body)* } }
                 [] ($($p)+,)
             }
         }
@@ -2741,7 +2741,7 @@ macro_rules! py_class_impl {
         /* impl: */ {
             $($imp)*
             $crate::py_argparse_parse_plist!{
-                py_class_impl_item { $class, $py, $name() $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, $name() $res_type; { $($body)* } }
                 ($($p)*)
             }
         }
@@ -2779,7 +2779,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, $name(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, $name(&$slf,) $res_type; { $($body)* } [] }
         }
         $members
         /* props: */ {
@@ -2801,7 +2801,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<Option<&$value_type>> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<Option<&$value_type>> = {} }] }
         }
         $members
         /* props: */ {
@@ -2823,7 +2823,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<&$value_type> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<&$value_type> = {} }] }
         }
         $members
         /* props: */ {
@@ -2845,7 +2845,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<$value_type> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<$value_type> = {} }] }
         }
         $members
         /* props: */ {

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -22,6 +22,8 @@
 // THIS IS A GENERATED FILE !!
 //       DO NOT MODIFY      !!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!
+//
+// REGENERATE USING THE MAKEFILE IN ROOT OF REPOSITORY: make build
 
 #[macro_export]
 #[doc(hidden)]

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -131,7 +131,7 @@ macro_rules! py_class_impl {
         $($imp)*
         $crate::py_coerce_item! {
             impl $class {
-                fn create_instance(py: $crate::Python $( , $data_name : $init_ty )* ) -> $crate::PyResult<$class> {
+                $($class_visibility)* fn create_instance(py: $crate::Python $( , $data_name : $init_ty )* ) -> $crate::PyResult<$class> {
                     let obj = unsafe {
                         <$class as $crate::py_class::BaseObject>::alloc(
                             py, &py.get_type::<$class>(), ( $($data_name,)* )

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -487,7 +487,7 @@ macro_rules! py_class_impl {
             $type_slots
             /* as_number */ [
                 $( $nb_slot_name : $nb_slot_value, )*
-                nb_bool: $crate::py_class_unary_slot!($class::__bool__, $crate::_detail::libc::c_int, $crate::py_class::slots::BoolConverter),
+                nb_nonzero: $crate::py_class_unary_slot!($class::__bool__, $crate::_detail::libc::c_int, $crate::py_class::slots::BoolConverter),
             ]
             $as_sequence $as_mapping $setdelitem
         }

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -22,6 +22,8 @@
 // THIS IS A GENERATED FILE !!
 //       DO NOT MODIFY      !!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!
+//
+// REGENERATE USING THE MAKEFILE IN ROOT OF REPOSITORY: make build
 
 #[macro_export]
 #[doc(hidden)]

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -131,7 +131,7 @@ macro_rules! py_class_impl {
         $($imp)*
         $crate::py_coerce_item! {
             impl $class {
-                fn create_instance(py: $crate::Python $( , $data_name : $init_ty )* ) -> $crate::PyResult<$class> {
+                $($class_visibility)* fn create_instance(py: $crate::Python $( , $data_name : $init_ty )* ) -> $crate::PyResult<$class> {
                     let obj = unsafe {
                         <$class as $crate::py_class::BaseObject>::alloc(
                             py, &py.get_type::<$class>(), ( $($data_name,)* )

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -387,7 +387,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __abs__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __abs__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -417,7 +417,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __add__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __add__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -459,7 +459,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __and__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __and__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -493,7 +493,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __bool__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __bool__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -521,7 +521,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __call__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __call__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -546,7 +546,7 @@ macro_rules! py_class_impl {
         /* impl: */ {
             $($imp)*
             $crate::py_argparse_parse_plist_impl!{
-                py_class_impl_item { $class, $py, __call__(&$slf,) $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, __call__(&$slf,) $res_type; { $($body)* } }
                 [] ($($p)+,)
             }
         }
@@ -586,7 +586,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : Option<&$item_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : Option<&$item_name> = {} }] }
         }
         $members $props
     }};
@@ -612,7 +612,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : &$item_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : &$item_name = {} }] }
         }
         $members $props
     }};
@@ -638,7 +638,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : $item_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __contains__(&$slf,) $res_type; { $($body)* } [{ $item : $item_name = {} }] }
         }
         $members $props
     }};
@@ -681,7 +681,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
         }
         $members $props
     }};
@@ -708,7 +708,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
         }
         $members $props
     }};
@@ -735,7 +735,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __delitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
         }
         $members $props
     }};
@@ -810,7 +810,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} }] }
         }
         $members $props
     }};
@@ -841,7 +841,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} }] }
         }
         $members $props
     }};
@@ -872,7 +872,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __getitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} }] }
         }
         $members $props
     }};
@@ -904,7 +904,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __hash__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __hash__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -934,7 +934,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -960,7 +960,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -986,7 +986,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iadd__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1016,7 +1016,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1042,7 +1042,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1068,7 +1068,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iand__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1102,7 +1102,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1128,7 +1128,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1154,7 +1154,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ifloordiv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1184,7 +1184,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1210,7 +1210,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1236,7 +1236,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ilshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1266,7 +1266,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1292,7 +1292,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1318,7 +1318,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imatmul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1348,7 +1348,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1374,7 +1374,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1400,7 +1400,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imod__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1430,7 +1430,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1456,7 +1456,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1482,7 +1482,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __imul__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1528,7 +1528,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __invert__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __invert__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -1558,7 +1558,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1584,7 +1584,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1610,7 +1610,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ior__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1644,7 +1644,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1670,7 +1670,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1696,7 +1696,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __irshift__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1726,7 +1726,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1752,7 +1752,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1778,7 +1778,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __isub__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1806,7 +1806,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __iter__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __iter__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -1836,7 +1836,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1862,7 +1862,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1888,7 +1888,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __itruediv__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -1918,7 +1918,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} }] }
         }
         $members $props
     }};
@@ -1944,7 +1944,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} }] }
         }
         $members $props
     }};
@@ -1970,7 +1970,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __ixor__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} }] }
         }
         $members $props
     }};
@@ -2009,7 +2009,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __len__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __len__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2043,7 +2043,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __lshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __lshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2085,7 +2085,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __mul__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __mul__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2119,7 +2119,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __neg__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __neg__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2147,7 +2147,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py,__new__($cls: &$crate::PyType,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __new__($cls: &$crate::PyType,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2172,7 +2172,7 @@ macro_rules! py_class_impl {
         /* impl: */ {
             $($imp)*
             $crate::py_argparse_parse_plist_impl!{
-                py_class_impl_item { $class, $py, __new__($cls: &$crate::PyType,) $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, __new__($cls: &$crate::PyType,) $res_type; { $($body)* } }
                 [] ($($p)+,)
             }
         }
@@ -2198,7 +2198,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __next__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __next__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2232,7 +2232,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __or__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __or__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2262,7 +2262,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __pos__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __pos__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2310,7 +2310,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __repr__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __repr__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2342,7 +2342,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} } { $op : $op_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : Option<&$other_name> = {} } { $op : $op_name = {} }] }
         }
         $members $props
     }};
@@ -2366,7 +2366,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} } { $op : $op_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : &$other_name = {} } { $op : $op_name = {} }] }
         }
         $members $props
     }};
@@ -2390,7 +2390,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} } { $op : $op_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __richcmp__(&$slf,) $res_type; { $($body)* } [{ $other : $other_name = {} } { $op : $op_name = {} }] }
         }
         $members $props
     }};
@@ -2452,7 +2452,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __rshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __rshift__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2503,7 +2503,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} } { $value : $value_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : Option<&$key_name> = {} } { $value : $value_name = {} }] }
         }
         $members $props
     }};
@@ -2530,7 +2530,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} } { $value : $value_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : &$key_name = {} } { $value : $value_name = {} }] }
         }
         $members $props
     }};
@@ -2557,7 +2557,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} } { $value : $value_name = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, __setitem__(&$slf,) $res_type; { $($body)* } [{ $key : $key_name = {} } { $value : $value_name = {} }] }
         }
         $members $props
     }};
@@ -2585,7 +2585,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __str__(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, __str__(&$slf,) $res_type; { $($body)* } [] }
         }
         $members $props
     }};
@@ -2615,7 +2615,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __sub__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __sub__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2653,7 +2653,7 @@ macro_rules! py_class_impl {
         }
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, __xor__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
+            $crate::py_class_impl_item! { $class, $py, pub, __xor__() $res_type; { $($body)* } [ { $left : &$crate::PyObject = {} } { $right : &$crate::PyObject = {} } ] }
         }
         $members $props
     }};
@@ -2670,7 +2670,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, $name(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, $name(&$slf,) $res_type; { $($body)* } [] }
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
@@ -2687,7 +2687,7 @@ macro_rules! py_class_impl {
         /* impl: */ {
             $($imp)*
             $crate::py_argparse_parse_plist_impl!{
-                py_class_impl_item { $class, $py, $name(&$slf,) $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, $name(&$slf,) $res_type; { $($body)* } }
                 [] ($($p)+,)
             }
         }
@@ -2705,7 +2705,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py,$name($cls: &$crate::PyType,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, $name($cls: &$crate::PyType,) $res_type; { $($body)* } [] }
         }
         /* members: */ {
             $( $member_name = $member_expr; )*
@@ -2722,7 +2722,7 @@ macro_rules! py_class_impl {
         /* impl: */ {
             $($imp)*
             $crate::py_argparse_parse_plist_impl!{
-                py_class_impl_item { $class, $py, $name($cls: &$crate::PyType,) $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, $name($cls: &$crate::PyType,) $res_type; { $($body)* } }
                 [] ($($p)+,)
             }
         }
@@ -2741,7 +2741,7 @@ macro_rules! py_class_impl {
         /* impl: */ {
             $($imp)*
             $crate::py_argparse_parse_plist!{
-                py_class_impl_item { $class, $py, $name() $res_type; { $($body)* } }
+                py_class_impl_item { $class, $py, pub, $name() $res_type; { $($body)* } }
                 ($($p)*)
             }
         }
@@ -2779,7 +2779,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, $name(&$slf,) $res_type; { $($body)* } [] }
+            $crate::py_class_impl_item! { $class, $py, pub, $name(&$slf,) $res_type; { $($body)* } [] }
         }
         $members
         /* props: */ {
@@ -2801,7 +2801,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<Option<&$value_type>> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<Option<&$value_type>> = {} }] }
         }
         $members
         /* props: */ {
@@ -2823,7 +2823,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<&$value_type> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<&$value_type> = {} }] }
         }
         $members
         /* props: */ {
@@ -2845,7 +2845,7 @@ macro_rules! py_class_impl {
         $class $py $info $slots
         /* impl: */ {
             $($imp)*
-            $crate::py_class_impl_item! { $class, $py, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<$value_type> = {} }] }
+            $crate::py_class_impl_item! { $class, $py, pub, $setter_name(&$slf,) $res_type; { $($body)* } [{ $value: Option<$value_type> = {} }] }
         }
         $members
         /* props: */ {

--- a/tests/test_class.rs
+++ b/tests/test_class.rs
@@ -1324,26 +1324,30 @@ fn class_with_visibility() {
     )
     .unwrap();
 
-    assert_eq!(ClassWithVisibility::static_method(py).unwrap(), "ClassWithVisibility.static_method()!");
+    assert_eq!(
+        ClassWithVisibility::static_method(py).unwrap(),
+        "ClassWithVisibility.static_method()!"
+    );
     let d = PyDict::new(py);
-    d.set_item(py, "C", py.get_type::<ClassWithVisibility>()).unwrap();
+    d.set_item(py, "C", py.get_type::<ClassWithVisibility>())
+        .unwrap();
     py.run(
         "assert C.static_method() == 'ClassWithVisibility.static_method()!'",
         None,
         Some(&d),
     )
-        .unwrap();
+    .unwrap();
     py.run(
         "assert C().static_method() == 'ClassWithVisibility.static_method()!'",
         None,
         Some(&d),
     )
-        .unwrap();
+    .unwrap();
 
     let obj = ClassWithVisibility::create_instance(py).unwrap();
     assert!(obj.instance_method(py).unwrap() == 12345);
     let d = PyDict::new(py);
     d.set_item(py, "obj", obj).unwrap();
-    py.run("assert obj.instance_method() == 12345", None, Some(&d)).unwrap();
+    py.run("assert obj.instance_method() == 12345", None, Some(&d))
+        .unwrap();
 }
-


### PR DESCRIPTION
Teach the `py_class` macros about allowing arbitrary visibility keywords (e.g., `pub(crate)`) on class definitions and the method definitions within that class definition. This PR also makes the `create_instance` method have the same visibility as the class.

[The `vis` capture type for visibility in macro_rules has been available since Rust v1.30.0.](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1300-2018-10-25)  Given that this crate requires v1.32 or higher, this PR does not break the crate's compatibility guarantee.

Note: The ultimate motivation for this PR is to allow me to split a very complicated use of this crate into multiple modules without having to make many types `pub`.