### PR TITLE
implement ToPyObject for unit value ()

### DIFF
--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -146,6 +146,7 @@ mod set;
 mod string;
 mod tuple;
 mod typeobject;
+mod unit;
 
 #[cfg(feature = "python27-sys")]
 pub mod oldstyle;

--- a/src/objects/unit.rs
+++ b/src/objects/unit.rs
@@ -1,0 +1,29 @@
+use super::PyObject;
+use crate::conversion::ToPyObject;
+use crate::err::PyResult;
+use crate::ffi;
+use crate::python::Python;
+
+impl ToPyObject for () {
+    type ObjectType = PyObject;
+
+    #[inline]
+    fn to_py_object(&self, py: Python) -> Self::ObjectType {
+        py.None()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Python, ToPyObject};
+
+    #[test]
+    fn test_unit_to_python() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        let py_none = ().to_py_object(py);
+
+        assert!(py_none == py.None());
+    }
+}


### PR DESCRIPTION
Implement ToPyObject for the unit value (i.e., `()`). This provides a more ergonomic way to declare functions that return `None` since this conversion allows the return value in the Rust declaration to be `PyResult<()>` instead of `PyResult<PyObject>` plus also having to call `Ok(py.None())`.