### PR TITLE
Disable test_thread_exit on Rust >= 1.48

### DIFF
--- a/tests/test_thread_exit.rs
+++ b/tests/test_thread_exit.rs
@@ -12,7 +12,9 @@ threading.Thread(target=sys.exit_thread).start()
         None,
         None,
     )?;
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    py.allow_threads(|| {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    });
     Ok(())
 }
 

--- a/tests/test_thread_exit.rs
+++ b/tests/test_thread_exit.rs
@@ -1,5 +1,6 @@
 use cpython::*;
 
+#[allow(unused)]
 fn test_thread_exit_py(py: Python) -> PyResult<()> {
     let m = py.import("sys")?;
     m.add(py, "exit_thread", py_fn!(py, exit_thread()))?;
@@ -25,12 +26,16 @@ threading.Thread(target=sys.exit_thread).start()
 // the stack. That exception does not inherit from C++ `std::exception` and
 // must be rethrown if caught, otherwise pthread will abort with
 // `FATAL: exception not rethrown`. On the Rust land, `catch_unwind` before
-// PR65646 will incorrectly silent that C++ exception without rethrowing,
+// PR65646 will incorrectly silence that C++ exception without rethrowing,
 // breaking this test.
+//
+// This test no longer works after Rust 1.48, as unwinding across ABI
+// boundaries is still undefined until the "C-unwind" project is complete.
+// See: https://github.com/rust-lang/rfcs/blob/master/text/2945-c-unwind-abi.md
 //
 // Also skip nightly compilers, which might include some unstable changes
 // affecting the test.
-#[rustversion::all(since(1.40), stable)]
+#[rustversion::all(since(1.40), before(1.48), stable)]
 #[test]
 fn test_thread_exit() {
     let gil = Python::acquire_gil();
@@ -38,6 +43,7 @@ fn test_thread_exit() {
     test_thread_exit_py(py).unwrap();
 }
 
+#[allow(unused)]
 fn exit_thread(py: Python) -> PyResult<String> {
     #[cfg(unix)]
     {


### PR DESCRIPTION
This test no longer works, so disable it.
I'm not sure what to do about the wider question of correctly handling `pthread_exit`.