### PR TITLE
Add PyNone to represent Python None

### DIFF
--- a/extensions/hello/src/hello.rs
+++ b/extensions/hello/src/hello.rs
@@ -21,7 +21,7 @@ fn func(_: Python, a: &str, b: i32) -> PyResult<String> {
     Ok(format!("func({}, {})", a, b))
 }
 
-fn run(py: Python, args: &PyTuple, kwargs: Option<&PyDict>) -> PyResult<PyObject> {
+fn run(py: Python, args: &PyTuple, kwargs: Option<&PyDict>) -> PyResult<PyNone> {
     println!("Rust says: Hello Python!");
     for arg in args.iter(py) {
         println!("Rust got {}", arg);
@@ -31,5 +31,5 @@ fn run(py: Python, args: &PyTuple, kwargs: Option<&PyDict>) -> PyResult<PyObject
             println!("{} = {}", key, val);
         }
     }
-    Ok(py.None())
+    Ok(PyNone)
 }

--- a/extensions/tests/custom_class.rs
+++ b/extensions/tests/custom_class.rs
@@ -1,6 +1,6 @@
 #![crate_type = "dylib"]
 
-use cpython::{PyObject, PyResult, py_module_initializer, py_class};
+use cpython::{py_class, py_module_initializer, PyNone, PyResult};
 
 py_module_initializer!(custom_class, |py, m| {
     m.add(py, "__doc__", "Module documentation string")?;
@@ -13,9 +13,8 @@ py_class!(class MyType |py| {
     def __new__(_cls, arg: i32) -> PyResult<MyType> {
         MyType::create_instance(py, arg)
     }
-    def a(&self) -> PyResult<PyObject> {
+    def a(&self) -> PyResult<PyNone> {
         println!("a() was called with self={:?}", self.data(py));
-        Ok(py.None())
+        Ok(PyNone)
     }
 });
-

--- a/extensions/tests/hello.rs
+++ b/extensions/tests/hello.rs
@@ -1,6 +1,6 @@
 #![crate_type = "dylib"]
 
-use cpython::{PyObject, PyResult, Python, PyTuple, PyDict, py_module_initializer, py_fn};
+use cpython::{py_fn, py_module_initializer, PyDict, PyNone, PyResult, PyTuple, Python};
 
 py_module_initializer!(hello, |py, m| {
     m.add(py, "__doc__", "Module documentation string")?;
@@ -9,7 +9,7 @@ py_module_initializer!(hello, |py, m| {
     Ok(())
 });
 
-fn run(py: Python, args: &PyTuple, kwargs: Option<&PyDict>) -> PyResult<PyObject> {
+fn run(py: Python, args: &PyTuple, kwargs: Option<&PyDict>) -> PyResult<PyNone> {
     println!("Rust says: Hello Python!");
     for arg in args.iter(py) {
         println!("Rust got {}", arg);
@@ -19,10 +19,9 @@ fn run(py: Python, args: &PyTuple, kwargs: Option<&PyDict>) -> PyResult<PyObject
             println!("{} = {}", key, val);
         }
     }
-    Ok(py.None())
+    Ok(PyNone)
 }
 
 fn val(_: Python) -> PyResult<i32> {
     Ok(42)
 }
-

--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -463,7 +463,7 @@ macro_rules! py_argparse_extract {
         // second unwrap() asserts the parameter was not missing (which fn parse_args already checked for).
         let v = $iter.next().unwrap().as_ref().unwrap();
         let mut c = |$pname: $ptype| $crate::py_argparse_extract!($py, $iter, $body, [$($tail)*]);
-        let r = if v.as_ptr() == unsafe { $crate::_detail::ffi::Py_None() } {
+        let r = if v.is_none($py) {
             Ok(c(None))
         } else {
             <$rtype as $crate::RefFromPyObject>::with_extracted($py, v, |r: &$rtype| c(Some(r)))
@@ -537,7 +537,7 @@ where
 {
     match obj {
         Some(obj) => {
-            if obj.as_ptr() == unsafe { crate::ffi::Py_None() } {
+            if obj.is_none(py) {
                 f(None)
             } else {
                 match P::with_extracted(py, obj, |p| f(Some(p))) {

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -224,7 +224,7 @@ where
     T: FromPyObject<'s>,
 {
     fn extract(py: Python, obj: &'s PyObject) -> PyResult<Self> {
-        if obj.as_ptr() == unsafe { ffi::Py_None() } {
+        if obj.is_none(py) {
             Ok(None)
         } else {
             match T::extract(py, obj) {
@@ -242,7 +242,7 @@ where T: ExtractPyObject<'prepared>
     type Prepared = Option<T::Prepared>;
 
     fn prepare_extract(py: Python, obj: &PyObject) -> PyResult<Self::Prepared> {
-        if obj.as_ptr() == unsafe { ffi::Py_None() } {
+        if obj.is_none(py) {
             Ok(None)
         } else {
             Ok(Some(T::prepare_extract(py, obj)?))

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -31,6 +31,7 @@ pub use self::capsule::PyCapsule;
 pub use self::dict::PyDict;
 pub use self::iterator::PyIterator;
 pub use self::list::PyList;
+pub use self::none::PyNone;
 #[cfg(feature = "python27-sys")]
 pub use self::num::PyInt;
 #[cfg(feature = "python3-sys")]
@@ -139,6 +140,7 @@ pub mod exc;
 mod iterator;
 mod list;
 mod module;
+mod none;
 mod num;
 mod object;
 mod sequence;

--- a/src/objects/none.rs
+++ b/src/objects/none.rs
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 Mark Juggurnauth-Thomas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use super::exc;
+use super::object::PyObject;
+use crate::conversion::{FromPyObject, ToPyObject};
+use crate::err::{PyErr, PyResult};
+use crate::python::{Python, PythonObject};
+
+/// An empty struct that represents `None` in Python.
+///
+/// This can be used as a function return type for functions that should return
+/// `None` in Python.
+///
+/// # Example
+/// ```
+/// use cpython::{Python, PyResult, PyNone};
+///
+/// fn example(py: Python) -> PyResult<PyNone> {
+///    Ok(PyNone)
+/// }
+/// ```
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Default, Hash, Ord)]
+pub struct PyNone;
+
+impl ToPyObject for PyNone {
+    type ObjectType = PyObject;
+
+    #[inline]
+    fn to_py_object(&self, py: Python) -> PyObject {
+        py.None()
+    }
+}
+
+impl FromPyObject<'_> for PyNone {
+    fn extract(py: Python, obj: &PyObject) -> PyResult<Self> {
+        if *obj == py.None() {
+            Ok(PyNone)
+        } else {
+            let msg = format!("Expected None but received {}", obj.get_type(py).name(py));
+            Err(PyErr::new_lazy_init(
+                py.get_type::<exc::TypeError>(),
+                Some(msg.to_py_object(py).into_object()),
+            ))
+        }
+    }
+}

--- a/src/objects/object.rs
+++ b/src/objects/object.rs
@@ -259,6 +259,12 @@ impl PyObject {
     {
         crate::conversion::FromPyObject::extract(py, self)
     }
+
+    /// True if this is None in Python.
+    #[inline]
+    pub fn is_none(&self, _py: Python) -> bool {
+        self.as_ptr() == unsafe { ffi::Py_None() }
+    }
 }
 
 /// PyObject implements the `==` operator using reference equality:

--- a/src/py_class/slots.rs
+++ b/src/py_class/slots.rs
@@ -266,7 +266,7 @@ macro_rules! py_class_call_slot_impl_with_ref {
         $arg_if_some:expr
         $(, $extra_arg:ident)*
     ) => {{
-        if $arg.as_ptr() == unsafe { $crate::_detail::ffi::Py_None() } {
+        if $arg.is_none($py) {
             Ok($slf.$f($py, $arg_if_none $(, $extra_arg)*))
         } else {
             <$arg_type as $crate::RefFromPyObject>::with_extracted(

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -85,7 +85,7 @@ impl<'gil> Deserializer<'gil> {
 
     /// Test whether `self.obj` is `None` in Python.
     fn is_none(&self) -> bool {
-        self.obj == self.py.None()
+        self.obj.is_none(self.py)
     }
 }
 

--- a/tests/test_function.rs
+++ b/tests/test_function.rs
@@ -135,14 +135,14 @@ fn opt_args() {
     });
 
     assert_eq!(
-        obj.call(py, (py.None(), "string"), None)
+        obj.call(py, (PyNone, "string"), None)
             .unwrap()
             .extract::<String>(py)
             .unwrap(),
         r#"a: None  b: "string"  c: None"#,
     );
     assert_eq!(
-        obj.call(py, ("double", "string", py.None()), None)
+        obj.call(py, ("double", "string", PyNone), None)
             .unwrap()
             .extract::<String>(py)
             .unwrap(),


### PR DESCRIPTION
Add a new zero-sized struct `PyNone`, that represents Python's `None`.  This is
similar to `NoArgs` for the empty tuple, and is useful for defining functions
or methods that return None in Python.