### PR TITLE
Increase MSRV to 1.41.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ python:
   - "3.8"
   - "3.9"
 env:
-  - RUST_VERSION=1.32.0
+  - RUST_VERSION=1.41.1
   - RUST_VERSION=stable
   - RUST_VERSION=nightly
 matrix:
   include:
     - os: osx
       language: generic
-      env: RUST_VERSION=1.32.0
+      env: RUST_VERSION=1.41.1
     - os: osx
       language: generic
       env: RUST_VERSION=stable

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supported Python versions:
 * Python 2.7
 * Python 3.3 to 3.9
 
-Requires Rust 1.32.0 or later.
+Requires Rust 1.41.1 or later.
 
 # Usage
 


### PR DESCRIPTION
The `thread_local` dependency now requires a minimum Rust version of
1.36.  Increase our MSRV to 1.41.1, which is the version in Debian
stable.