### PR TITLE
Fix or suppress warnings and format code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ endif
 doc: build
 	cargo doc --no-deps $(CARGO_FLAGS)
 
+clippy:
+	cargo clippy $(CARGO_FLAGS)
+
 extensions: build
 	make -C extensions/tests PY=$(PY)
 

--- a/build.rs
+++ b/build.rs
@@ -1,26 +1,20 @@
 use std::env;
-use std::io::Write;
 
-const CFG_KEY: &'static str = "py_sys_config";
+const CFG_KEY: &str = "py_sys_config";
 
 #[cfg(feature = "python27-sys")]
-const PYTHONSYS_ENV_VAR: &'static str = "DEP_PYTHON27_PYTHON_FLAGS";
+const PYTHONSYS_ENV_VAR: &str = "DEP_PYTHON27_PYTHON_FLAGS";
 
 #[cfg(feature = "python3-sys")]
-const PYTHONSYS_ENV_VAR: &'static str = "DEP_PYTHON3_PYTHON_FLAGS";
+const PYTHONSYS_ENV_VAR: &str = "DEP_PYTHON3_PYTHON_FLAGS";
 
 fn main() {
-    if cfg!(feature = "python27-sys") {
-        if env::var_os("CARGO_FEATURE_PY_LINK_MODE_DEFAULT").is_some()
-            || env::var_os("CARGO_FEATURE_PY_LINK_MODE_UNRESOLVED_STATIC").is_some()
-        {
-            writeln!(
-                std::io::stderr(),
-                "Cannot use link mode control with Python 2.7"
-            )
-            .unwrap();
-            std::process::exit(1);
-        }
+    if cfg!(feature = "python27-sys")
+        && (env::var_os("CARGO_FEATURE_PY_LINK_MODE_DEFAULT").is_some()
+            || env::var_os("CARGO_FEATURE_PY_LINK_MODE_UNRESOLVED_STATIC").is_some())
+    {
+        eprintln!("Cannot use link mode control with Python 2.7");
+        std::process::exit(1);
     }
 
     // python{27,3.x}-sys/build.rs passes python interpreter compile flags via
@@ -28,22 +22,23 @@ fn main() {
     let flags = match env::var(PYTHONSYS_ENV_VAR) {
         Ok(flags) => flags,
         Err(_) => {
-            writeln!(
-                std::io::stderr(),
-                "Environment variable {} not found - this is supposed to be \
-                 exported from the pythonXX-sys dependency, so the build chain is broken",
+            eprintln!(
+                concat!(
+                    "Environment variable {} not found - this is supposed to be ",
+                    "exported from the pythonXX-sys dependency, so the build ",
+                    "chain is broken"
+                ),
                 PYTHONSYS_ENV_VAR
-            )
-            .unwrap();
+            );
             std::process::exit(1);
         }
     };
 
-    if flags.len() > 0 {
-        for f in flags.split(",") {
+    if !flags.is_empty() {
+        for f in flags.split(',') {
             // write out flags as --cfg so that the same #cfg blocks can be used
             // in rust-cpython as in the -sys libs
-            let key_and_val: Vec<&str> = f.split("=").collect();
+            let key_and_val: Vec<&str> = f.split('=').collect();
             let key = key_and_val[0];
             let val = key_and_val[1];
             if key.starts_with("FLAG") {

--- a/python27-sys/build.rs
+++ b/python27-sys/build.rs
@@ -296,9 +296,7 @@ fn find_interpreter_and_get_config(
     }
 
     for name in possible_names.iter() {
-        if let Ok((executable, interpreter_version, lines)) =
-            get_config_from_interpreter(name)
-        {
+        if let Ok((executable, interpreter_version, lines)) = get_config_from_interpreter(name) {
             if matching_version(expected_version, &interpreter_version) {
                 return Ok((interpreter_version, executable, lines));
             }

--- a/python27-sys/src/code.rs
+++ b/python27-sys/src/code.rs
@@ -78,9 +78,15 @@ extern "C" {
         firstlineno: c_int,
     ) -> *mut PyCodeObject;
     pub fn PyCode_Addr2Line(arg1: *mut PyCodeObject, arg2: c_int) -> c_int;
-    //fn _PyCode_CheckLineNumber(co: *mut PyCodeObject,
-    //                               lasti: c_int,
-    //                               bounds: *mut PyAddrPair) -> c_int;
+
+    ignore! {
+        fn _PyCode_CheckLineNumber(
+            co: *mut PyCodeObject,
+            lasti: c_int,
+            bounds: *mut PyAddrPair,
+        ) -> c_int;
+    }
+
     pub fn PyCode_Optimize(
         code: *mut PyObject,
         consts: *mut PyObject,

--- a/python27-sys/src/compile.rs
+++ b/python27-sys/src/compile.rs
@@ -11,13 +11,13 @@ pub struct PyFutureFeatures {
     pub ff_lineno: c_int,
 }
 
-pub const FUTURE_NESTED_SCOPES: &'static str = "nested_scopes";
-pub const FUTURE_GENERATORS: &'static str = "generators";
-pub const FUTURE_DIVISION: &'static str = "division";
-pub const FUTURE_ABSOLUTE_IMPORT: &'static str = "absolute_import";
-pub const FUTURE_WITH_STATEMENT: &'static str = "with_statement";
-pub const FUTURE_PRINT_FUNCTION: &'static str = "print_function";
-pub const FUTURE_UNICODE_LITERALS: &'static str = "unicode_literals";
+pub const FUTURE_NESTED_SCOPES: &str = "nested_scopes";
+pub const FUTURE_GENERATORS: &str = "generators";
+pub const FUTURE_DIVISION: &str = "division";
+pub const FUTURE_ABSOLUTE_IMPORT: &str = "absolute_import";
+pub const FUTURE_WITH_STATEMENT: &str = "with_statement";
+pub const FUTURE_PRINT_FUNCTION: &str = "print_function";
+pub const FUTURE_UNICODE_LITERALS: &str = "unicode_literals";
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/python27-sys/src/complexobject.rs
+++ b/python27-sys/src/complexobject.rs
@@ -57,8 +57,11 @@ extern "C" {
     pub fn PyComplex_ImagAsDouble(op: *mut PyObject) -> c_double;
     pub fn PyComplex_AsCComplex(op: *mut PyObject) -> Py_complex;
 
-//fn _PyComplex_FormatAdvanced(obj: *mut PyObject,
-//                                 format_spec: *mut c_char,
-//                                 format_spec_len: Py_ssize_t)
-// -> *mut PyObject;
+    ignore! {
+        fn _PyComplex_FormatAdvanced(
+            obj: *mut PyObject,
+            format_spec: *mut c_char,
+            format_spec_len: Py_ssize_t,
+        ) -> *mut PyObject;
+    }
 }

--- a/python27-sys/src/descrobject.rs
+++ b/python27-sys/src/descrobject.rs
@@ -87,7 +87,9 @@ pub unsafe fn PyDescr_IsData(d: *mut PyObject) -> c_int {
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
-    //pub fn PyDictProxy_New(arg1: *mut PyObject) -> *mut PyObject;
-    // PyDictProxy_New is also defined in dictobject.h
+    ignore! {
+        // PyDictProxy_New is also defined in dictobject.h
+        pub fn PyDictProxy_New(arg1: *mut PyObject) -> *mut PyObject;
+    }
     pub fn PyWrapper_New(arg1: *mut PyObject, arg2: *mut PyObject) -> *mut PyObject;
 }

--- a/python27-sys/src/dictobject.rs
+++ b/python27-sys/src/dictobject.rs
@@ -3,7 +3,10 @@ use libc::{c_char, c_int};
 use crate::object::*;
 use crate::pyport::Py_ssize_t;
 
-//#[repr(C)] pub struct PyDictObject { /* representation hidden */ }
+ignore! {
+    #[repr(C)]
+    pub struct PyDictObject { /* representation hidden */ }
+}
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
@@ -56,13 +59,18 @@ extern "C" {
         key: *mut *mut PyObject,
         value: *mut *mut PyObject,
     ) -> c_int;
-    /*pub fn _PyDict_Next(mp: *mut PyObject, pos: *mut Py_ssize_t,
-                        key: *mut *mut PyObject, value: *mut *mut PyObject,
-                        hash: *mut c_long) -> c_int;
-    pub fn _PyDict_Contains(mp: *mut PyObject, key: *mut PyObject,
-                            hash: c_long) -> c_int;
-    pub fn _PyDict_NewPresized(minused: Py_ssize_t) -> *mut PyObject;
-    pub fn _PyDict_MaybeUntrack(mp: *mut PyObject);*/
+    ignore! {
+        pub fn _PyDict_Next(
+            mp: *mut PyObject,
+            pos: *mut Py_ssize_t,
+            key: *mut *mut PyObject,
+            value: *mut *mut PyObject,
+            hash: *mut c_long,
+        ) -> c_int;
+        pub fn _PyDict_Contains(mp: *mut PyObject, key: *mut PyObject, hash: c_long) -> c_int;
+        pub fn _PyDict_NewPresized(minused: Py_ssize_t) -> *mut PyObject;
+        pub fn _PyDict_MaybeUntrack(mp: *mut PyObject);
+    }
     pub fn PyDict_Update(mp: *mut PyObject, other: *mut PyObject) -> c_int;
     pub fn PyDict_Merge(mp: *mut PyObject, other: *mut PyObject, _override: c_int) -> c_int;
     pub fn PyDict_MergeFromSeq2(d: *mut PyObject, seq2: *mut PyObject, _override: c_int) -> c_int;

--- a/python27-sys/src/fileobject.rs
+++ b/python27-sys/src/fileobject.rs
@@ -36,8 +36,10 @@ extern "C" {
         arg4: Option<unsafe extern "C" fn(arg1: *mut FILE) -> c_int>,
     ) -> *mut PyObject;
     pub fn PyFile_AsFile(arg1: *mut PyObject) -> *mut FILE;
-    //pub fn PyFile_IncUseCount(arg1: *mut PyFileObject);
-    //pub fn PyFile_DecUseCount(arg1: *mut PyFileObject);
+    ignore! {
+        pub fn PyFile_IncUseCount(arg1: *mut PyFileObject);
+        pub fn PyFile_DecUseCount(arg1: *mut PyFileObject);
+    }
     pub fn PyFile_Name(arg1: *mut PyObject) -> *mut PyObject;
     pub fn PyFile_GetLine(arg1: *mut PyObject, arg2: c_int) -> *mut PyObject;
     pub fn PyFile_WriteObject(arg1: *mut PyObject, arg2: *mut PyObject, arg3: c_int) -> c_int;

--- a/python27-sys/src/fileobject.rs
+++ b/python27-sys/src/fileobject.rs
@@ -17,7 +17,7 @@ pub unsafe fn PyFile_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyFile_Type) as c_int
 }
 
-pub const PY_STDIOTEXTMODE: &'static str = "b";
+pub const PY_STDIOTEXTMODE: &str = "b";
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/python27-sys/src/frameobject.rs
+++ b/python27-sys/src/frameobject.rs
@@ -63,10 +63,12 @@ pub unsafe fn PyFrame_Check(op: *mut PyObject) -> c_int {
     ((*op).ob_type == &mut PyFrame_Type) as c_int
 }
 
-//#[inline]
-//pub unsafe fn PyFrame_IsRestricted(f: *mut PyFrameObject) -> c_int {
-//     ((*f).f_builtins != (*(*(*f).f_tstate).interp).builtins) as c_int
-//}
+ignore! {
+    #[inline]
+    pub unsafe fn PyFrame_IsRestricted(f: *mut PyFrameObject) -> c_int {
+        ((*f).f_builtins != (*(*(*f).f_tstate).interp).builtins) as c_int
+    }
+}
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/python27-sys/src/import.rs
+++ b/python27-sys/src/import.rs
@@ -69,22 +69,22 @@ extern "C" {
     pub static mut PyImport_Inittab: *mut PyImport_Struct_inittab;
     pub static mut PyImport_FrozenModules: *mut PyImport_Struct_frozen;
 
-/*for internal use only:
-pub fn PyImport_Cleanup();
-pub fn _PyImport_AcquireLock();
-pub fn _PyImport_ReleaseLock() -> c_int;
-pub fn _PyImport_FindModule(arg1: *const c_char,
-                            arg2: *mut PyObject,
-                            arg3: *mut c_char, arg4: size_t,
-                            arg5: *mut *mut FILE,
-                            arg6: *mut *mut PyObject)
- -> *mut Struct_filedescr;
-pub fn _PyImport_IsScript(arg1: *mut Struct_filedescr) -> c_int;
-pub fn _PyImport_ReInitLock();
-pub fn _PyImport_FindExtension(arg1: *mut c_char,
-                               arg2: *mut c_char)
- -> *mut PyObject;
-pub fn _PyImport_FixupExtension(arg1: *mut c_char,
-                                arg2: *mut c_char)
- -> *mut PyObject;*/
+    ignore! {
+        // For internal use only
+        pub fn PyImport_Cleanup();
+        pub fn _PyImport_AcquireLock();
+        pub fn _PyImport_ReleaseLock() -> c_int;
+        pub fn _PyImport_FindModule(
+            arg1: *const c_char,
+            arg2: *mut PyObject,
+            arg3: *mut c_char,
+            arg4: size_t,
+            arg5: *mut *mut FILE,
+            arg6: *mut *mut PyObject,
+        ) -> *mut Struct_filedescr;
+        pub fn _PyImport_IsScript(arg1: *mut Struct_filedescr) -> c_int;
+        pub fn _PyImport_ReInitLock();
+        pub fn _PyImport_FindExtension(arg1: *mut c_char, arg2: *mut c_char) -> *mut PyObject;
+        pub fn _PyImport_FixupExtension(arg1: *mut c_char, arg2: *mut c_char) -> *mut PyObject;
+    }
 }

--- a/python27-sys/src/intobject.rs
+++ b/python27-sys/src/intobject.rs
@@ -50,19 +50,19 @@ extern "C" {
     pub fn PyInt_AsUnsignedLongMask(io: *mut PyObject) -> c_ulong;
     pub fn PyInt_AsUnsignedLongLongMask(io: *mut PyObject) -> c_ulonglong;
     pub fn PyInt_GetMax() -> c_long;
-    //fn PyOS_strtoul(arg1: *mut c_char,
-    //                   arg2: *mut *mut c_char, arg3: c_int)
-    // -> c_ulong;
-    //fn PyOS_strtol(arg1: *mut c_char,
-    //                  arg2: *mut *mut c_char, arg3: c_int)
-    // -> c_long;
+    ignore! {
+        fn PyOS_strtoul(arg1: *mut c_char, arg2: *mut *mut c_char, arg3: c_int) -> c_ulong;
+        fn PyOS_strtol(arg1: *mut c_char, arg2: *mut *mut c_char, arg3: c_int) -> c_long;
+    }
     pub fn PyInt_ClearFreeList() -> c_int;
-//fn _PyInt_Format(v: *mut PyIntObject, base: c_int,
-//                     newstyle: c_int) -> *mut PyObject;
-//fn _PyInt_FormatAdvanced(obj: *mut PyObject,
-//                             format_spec: *mut c_char,
-//                             format_spec_len: Py_ssize_t)
-// -> *mut PyObject;
+    ignore! {
+        fn _PyInt_Format(v: *mut PyIntObject, base: c_int, newstyle: c_int) -> *mut PyObject;
+        fn _PyInt_FormatAdvanced(
+            obj: *mut PyObject,
+            format_spec: *mut c_char,
+            format_spec_len: Py_ssize_t,
+        ) -> *mut PyObject;
+    }
 }
 
 pub unsafe fn PyInt_AS_LONG(io: *mut PyObject) -> c_long {

--- a/python27-sys/src/lib.rs
+++ b/python27-sys/src/lib.rs
@@ -7,8 +7,13 @@
     clippy::missing_safety_doc,
     clippy::transmute_ptr_to_ptr,
     clippy::unused_unit,
-    clippy::identity_op,
+    clippy::identity_op
 )]
+
+// Macro for marking parts of the Python headers as ignored.
+macro_rules! ignore {
+    ( $( $_tokens:tt )* ) => {};
+}
 
 pub use crate::boolobject::*;
 pub use crate::bufferobject::*;

--- a/python27-sys/src/lib.rs
+++ b/python27-sys/src/lib.rs
@@ -3,7 +3,11 @@
     non_camel_case_types,
     non_upper_case_globals,
     non_snake_case,
-    unused_parens
+    unused_parens,
+    clippy::missing_safety_doc,
+    clippy::transmute_ptr_to_ptr,
+    clippy::unused_unit,
+    clippy::identity_op,
 )]
 
 pub use crate::boolobject::*;

--- a/python27-sys/src/listobject.rs
+++ b/python27-sys/src/listobject.rs
@@ -69,6 +69,7 @@ extern "C" {
     pub fn PyList_Sort(list: *mut PyObject) -> c_int;
     pub fn PyList_Reverse(list: *mut PyObject) -> c_int;
     pub fn PyList_AsTuple(list: *mut PyObject) -> *mut PyObject;
-//fn _PyList_Extend(arg1: *mut PyListObject, arg2: *mut PyObject)
-//-> *mut PyObject;
+    ignore! {
+        fn _PyList_Extend(arg1: *mut PyListObject, arg2: *mut PyObject) -> *mut PyObject;
+    }
 }

--- a/python27-sys/src/longobject.rs
+++ b/python27-sys/src/longobject.rs
@@ -3,7 +3,10 @@ use libc::{c_char, c_double, c_int, c_long, c_longlong, c_ulong, c_ulonglong, c_
 use crate::object::*;
 use crate::pyport::Py_ssize_t;
 
-//#[repr(C)] struct PyLongObject { /* representation hidden */ }
+ignore! {
+    #[repr(C)]
+    struct PyLongObject { /* representation hidden */ }
+}
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
@@ -57,25 +60,34 @@ extern "C" {
 
     pub fn PyLong_GetInfo() -> *mut PyObject;
 
-/*
-pub fn _PyLong_AsInt(arg1: *mut PyObject) -> c_int;
-pub fn _PyLong_Frexp(a: *mut PyLongObject, e: *mut Py_ssize_t)
- -> c_double;
-
-pub fn _PyLong_Sign(v: *mut PyObject) -> c_int;
-pub fn _PyLong_NumBits(v: *mut PyObject) -> size_t;
-pub fn _PyLong_FromByteArray(bytes: *const c_uchar, n: size_t,
-                             little_endian: c_int,
-                             is_signed: c_int) -> *mut PyObject;
-pub fn _PyLong_AsByteArray(v: *mut PyLongObject,
-                           bytes: *mut c_uchar, n: size_t,
-                           little_endian: c_int,
-                           is_signed: c_int) -> c_int;
-pub fn _PyLong_Format(aa: *mut PyObject, base: c_int,
-                      addL: c_int, newstyle: c_int)
- -> *mut PyObject;
-pub fn _PyLong_FormatAdvanced(obj: *mut PyObject,
-                              format_spec: *mut c_char,
-                              format_spec_len: Py_ssize_t)
- -> *mut PyObject;*/
+    ignore! {
+        pub fn _PyLong_AsInt(arg1: *mut PyObject) -> c_int;
+        pub fn _PyLong_Frexp(a: *mut PyLongObject, e: *mut Py_ssize_t) -> c_double;
+        pub fn _PyLong_Sign(v: *mut PyObject) -> c_int;
+        pub fn _PyLong_NumBits(v: *mut PyObject) -> size_t;
+        pub fn _PyLong_FromByteArray(
+            bytes: *const c_uchar,
+            n: size_t,
+            little_endian: c_int,
+            is_signed: c_int,
+        ) -> *mut PyObject;
+        pub fn _PyLong_AsByteArray(
+            v: *mut PyLongObject,
+            bytes: *mut c_uchar,
+            n: size_t,
+            little_endian: c_int,
+            is_signed: c_int,
+        ) -> c_int;
+        pub fn _PyLong_Format(
+            aa: *mut PyObject,
+            base: c_int,
+            addL: c_int,
+            newstyle: c_int,
+        ) -> *mut PyObject;
+        pub fn _PyLong_FormatAdvanced(
+            obj: *mut PyObject,
+            format_spec: *mut c_char,
+            format_spec_len: Py_ssize_t,
+        ) -> *mut PyObject;
+    }
 }

--- a/python27-sys/src/modsupport.rs
+++ b/python27-sys/src/modsupport.rs
@@ -24,10 +24,12 @@ extern "C" {
         ...
     ) -> c_int;
     pub fn Py_BuildValue(format: *const c_char, ...) -> *mut PyObject;
-    //fn _Py_BuildValue_SizeT(arg1: *const c_char, ...)
-    // -> *mut PyObject;
-    //fn _PyArg_NoKeywords(funcname: *const c_char,
-    //                     kw: *mut PyObject) -> c_int;
+
+    ignore! {
+        fn _Py_BuildValue_SizeT(arg1: *const c_char, ...) -> *mut PyObject;
+        fn _PyArg_NoKeywords(funcname: *const c_char, kw: *mut PyObject) -> c_int;
+    }
+
     pub fn PyModule_AddObject(
         module: *mut PyObject,
         name: *const c_char,

--- a/python27-sys/src/moduleobject.rs
+++ b/python27-sys/src/moduleobject.rs
@@ -10,7 +10,9 @@ extern "C" {
     pub fn PyModule_GetDict(module: *mut PyObject) -> *mut PyObject;
     pub fn PyModule_GetName(module: *mut PyObject) -> *mut c_char;
     pub fn PyModule_GetFilename(module: *mut PyObject) -> *mut c_char;
-//fn _PyModule_Clear(arg1: *mut PyObject);
+    ignore! {
+        fn _PyModule_Clear(arg1: *mut PyObject);
+    }
 }
 
 #[inline(always)]

--- a/python27-sys/src/pyarena.rs
+++ b/python27-sys/src/pyarena.rs
@@ -3,7 +3,10 @@ use libc::{c_int, c_void, size_t};
 use crate::object::PyObject;
 
 #[allow(missing_copy_implementations)]
-#[repr(C)] pub struct PyArena { _private: [u8; 0] }
+#[repr(C)]
+pub struct PyArena {
+    _private: [u8; 0],
+}
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/python27-sys/src/pystate.rs
+++ b/python27-sys/src/pystate.rs
@@ -3,7 +3,10 @@ use libc::{c_int, c_long};
 use crate::frameobject::PyFrameObject;
 use crate::object::PyObject;
 
-#[repr(C)] pub struct PyInterpreterState { _private: [u8; 0] }
+#[repr(C)]
+pub struct PyInterpreterState {
+    _private: [u8; 0],
+}
 
 pub type Py_tracefunc = unsafe extern "C" fn(
     arg1: *mut PyObject,

--- a/python27-sys/src/pythonrun.rs
+++ b/python27-sys/src/pythonrun.rs
@@ -22,13 +22,22 @@ pub struct PyCompilerFlags {
 }
 
 #[allow(missing_copy_implementations)]
-#[repr(C)] pub struct Struct__mod { _private: [u8; 0] }
+#[repr(C)]
+pub struct Struct__mod {
+    _private: [u8; 0],
+}
 
 #[allow(missing_copy_implementations)]
-#[repr(C)] pub struct Struct__node { _private: [u8; 0] }
+#[repr(C)]
+pub struct Struct__node {
+    _private: [u8; 0],
+}
 
 #[allow(missing_copy_implementations)]
-#[repr(C)] pub struct Struct_symtable { _private: [u8; 0] }
+#[repr(C)]
+pub struct Struct_symtable {
+    _private: [u8; 0],
+}
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/python27-sys/src/setobject.rs
+++ b/python27-sys/src/setobject.rs
@@ -3,7 +3,9 @@ use libc::c_int;
 use crate::object::*;
 use crate::pyport::Py_ssize_t;
 
-//#[repr(C)] pub struct PySetObject { _private: [u8; 0] }
+ignore! {
+    #[repr(C)] pub struct PySetObject { _private: [u8; 0] }
+}
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
@@ -52,12 +54,20 @@ extern "C" {
     pub fn PySet_Contains(anyset: *mut PyObject, key: *mut PyObject) -> c_int;
     pub fn PySet_Discard(set: *mut PyObject, key: *mut PyObject) -> c_int;
     pub fn PySet_Add(set: *mut PyObject, key: *mut PyObject) -> c_int;
-    //pub fn _PySet_Next(set: *mut PyObject, pos: *mut Py_ssize_t,
-    //                   key: *mut *mut PyObject) -> c_int;
-    //pub fn _PySet_NextEntry(set: *mut PyObject, pos: *mut Py_ssize_t,
-    //                        key: *mut *mut PyObject,
-    //                        hash: *mut c_long) -> c_int;
+
+    ignore! {
+        pub fn _PySet_Next(set: *mut PyObject, pos: *mut Py_ssize_t, key: *mut *mut PyObject) -> c_int;
+        pub fn _PySet_NextEntry(
+            set: *mut PyObject,
+            pos: *mut Py_ssize_t,
+            key: *mut *mut PyObject,
+            hash: *mut c_long,
+        ) -> c_int;
+    }
+
     pub fn PySet_Pop(set: *mut PyObject) -> *mut PyObject;
-//pub fn _PySet_Update(set: *mut PyObject, iterable: *mut PyObject)
-// -> c_int;
+
+    ignore! {
+        pub fn _PySet_Update(set: *mut PyObject, iterable: *mut PyObject) -> c_int;
+    }
 }

--- a/python27-sys/src/stringobject.rs
+++ b/python27-sys/src/stringobject.rs
@@ -86,53 +86,58 @@ extern "C" {
         errors: *const c_char,
     ) -> *mut PyObject;
 
-/*
-pub fn PyString_Repr(arg1: *mut PyObject, arg2: c_int)
- -> *mut PyObject;
-pub fn _PyString_Eq(arg1: *mut PyObject, arg2: *mut PyObject)
- -> c_int;
-pub fn _PyString_FormatLong(arg1: *mut PyObject, arg2: c_int,
-                            arg3: c_int, arg4: c_int,
-                            arg5: *mut *mut c_char,
-                            arg6: *mut c_int) -> *mut PyObject;
-pub fn PyString_DecodeEscape(arg1: *const c_char,
-                             arg2: Py_ssize_t,
-                             arg3: *const c_char,
-                             arg4: Py_ssize_t,
-                             arg5: *const c_char)
- -> *mut PyObject;
-pub fn PyString_InternImmortal(arg1: *mut *mut PyObject);
-pub fn _Py_ReleaseInternedStrings();
-pub fn _PyString_Join(sep: *mut PyObject, x: *mut PyObject)
- -> *mut PyObject;
-pub fn PyString_AsEncodedString(str: *mut PyObject,
-                                encoding: *const c_char,
-                                errors: *const c_char)
- -> *mut PyObject;
-pub fn PyString_AsDecodedString(str: *mut PyObject,
-                                encoding: *const c_char,
-                                errors: *const c_char)
- -> *mut PyObject;
+    ignore! {
+        pub fn PyString_Repr(arg1: *mut PyObject, arg2: c_int) -> *mut PyObject;
+        pub fn _PyString_Eq(arg1: *mut PyObject, arg2: *mut PyObject) -> c_int;
+        pub fn _PyString_FormatLong(
+            arg1: *mut PyObject,
+            arg2: c_int,
+            arg3: c_int,
+            arg4: c_int,
+            arg5: *mut *mut c_char,
+            arg6: *mut c_int,
+        ) -> *mut PyObject;
+        pub fn PyString_DecodeEscape(
+            arg1: *const c_char,
+            arg2: Py_ssize_t,
+            arg3: *const c_char,
+            arg4: Py_ssize_t,
+            arg5: *const c_char,
+        ) -> *mut PyObject;
+        pub fn PyString_InternImmortal(arg1: *mut *mut PyObject);
+        pub fn _Py_ReleaseInternedStrings();
+        pub fn _PyString_Join(sep: *mut PyObject, x: *mut PyObject) -> *mut PyObject;
+        pub fn PyString_AsEncodedString(
+            str: *mut PyObject,
+            encoding: *const c_char,
+            errors: *const c_char,
+        ) -> *mut PyObject;
+        pub fn PyString_AsDecodedString(
+            str: *mut PyObject,
+            encoding: *const c_char,
+            errors: *const c_char,
+        ) -> *mut PyObject;
 
-pub fn _PyString_InsertThousandsGroupingLocale(buffer:
-                                                   *mut c_char,
-                                               n_buffer: Py_ssize_t,
-                                               digits:
-                                                   *mut c_char,
-                                               n_digits: Py_ssize_t,
-                                               min_width: Py_ssize_t)
- -> Py_ssize_t;
-pub fn _PyString_InsertThousandsGrouping(buffer: *mut c_char,
-                                         n_buffer: Py_ssize_t,
-                                         digits: *mut c_char,
-                                         n_digits: Py_ssize_t,
-                                         min_width: Py_ssize_t,
-                                         grouping: *const c_char,
-                                         thousands_sep:
-                                             *const c_char)
- -> Py_ssize_t;
-pub fn _PyBytes_FormatAdvanced(obj: *mut PyObject,
-                               format_spec: *mut c_char,
-                               format_spec_len: Py_ssize_t)
- -> *mut PyObject;*/
+        pub fn _PyString_InsertThousandsGroupingLocale(
+            buffer: *mut c_char,
+            n_buffer: Py_ssize_t,
+            digits: *mut c_char,
+            n_digits: Py_ssize_t,
+            min_width: Py_ssize_t,
+        ) -> Py_ssize_t;
+        pub fn _PyString_InsertThousandsGrouping(
+            buffer: *mut c_char,
+            n_buffer: Py_ssize_t,
+            digits: *mut c_char,
+            n_digits: Py_ssize_t,
+            min_width: Py_ssize_t,
+            grouping: *const c_char,
+            thousands_sep: *const c_char,
+        ) -> Py_ssize_t;
+        pub fn _PyBytes_FormatAdvanced(
+            obj: *mut PyObject,
+            format_spec: *mut c_char,
+            format_spec_len: Py_ssize_t,
+        ) -> *mut PyObject;
+    }
 }

--- a/python27-sys/src/tupleobject.rs
+++ b/python27-sys/src/tupleobject.rs
@@ -64,6 +64,8 @@ extern "C" {
     pub fn PyTuple_GetSlice(p: *mut PyObject, low: Py_ssize_t, high: Py_ssize_t) -> *mut PyObject;
     pub fn _PyTuple_Resize(p: *mut *mut PyObject, newsize: Py_ssize_t) -> c_int;
     pub fn PyTuple_Pack(n: Py_ssize_t, ...) -> *mut PyObject;
-    //pub fn _PyTuple_MaybeUntrack(arg1: *mut PyObject);
+    ignore! {
+        pub fn _PyTuple_MaybeUntrack(arg1: *mut PyObject);
+    }
     pub fn PyTuple_ClearFreeList() -> c_int;
 }

--- a/python3-sys/build.rs
+++ b/python3-sys/build.rs
@@ -293,9 +293,7 @@ fn find_interpreter_and_get_config(
     }
 
     for name in possible_names.iter() {
-        if let Ok((executable, interpreter_version, lines)) =
-            get_config_from_interpreter(name)
-        {
+        if let Ok((executable, interpreter_version, lines)) = get_config_from_interpreter(name) {
             if matching_version(expected_version, &interpreter_version) {
                 return Ok((interpreter_version, executable, lines));
             }

--- a/python3-sys/build.rs
+++ b/python3-sys/build.rs
@@ -22,15 +22,15 @@ impl fmt::Display for PythonVersion {
     }
 }
 
-const CFG_KEY: &'static str = "py_sys_config";
+const CFG_KEY: &str = "py_sys_config";
 
 // windows' python writes out lines with the windows crlf sequence;
 // posix platforms and mac os should write out lines with just lf.
 #[cfg(target_os = "windows")]
-static NEWLINE_SEQUENCE: &'static str = "\r\n";
+static NEWLINE_SEQUENCE: &str = "\r\n";
 
 #[cfg(not(target_os = "windows"))]
-static NEWLINE_SEQUENCE: &'static str = "\n";
+static NEWLINE_SEQUENCE: &str = "\n";
 
 // A list of python interpreter compile-time preprocessor defines that
 // we will pick up and pass to rustc via --cfg=py_sys_config={varname};
@@ -45,7 +45,7 @@ static NEWLINE_SEQUENCE: &'static str = "\n";
 // (hrm, this is sort of re-implementing what distutils does, except
 // by passing command line args instead of referring to a python.h)
 #[cfg(not(target_os = "windows"))]
-static SYSCONFIG_FLAGS: [&'static str; 7] = [
+static SYSCONFIG_FLAGS: [&str; 7] = [
     "Py_USING_UNICODE",
     "Py_UNICODE_WIDE",
     "WITH_THREAD",
@@ -55,7 +55,7 @@ static SYSCONFIG_FLAGS: [&'static str; 7] = [
     "COUNT_ALLOCS",
 ];
 
-static SYSCONFIG_VALUES: [&'static str; 1] = [
+static SYSCONFIG_VALUES: [&str; 1] = [
     // cfg doesn't support flags with values, just bools - so flags
     // below are translated into bools as {varname}_{val}
     //
@@ -67,7 +67,7 @@ static SYSCONFIG_VALUES: [&'static str; 1] = [
 /// the interpreter and printing variables of interest from
 /// sysconfig.get_config_vars.
 #[cfg(not(target_os = "windows"))]
-fn get_config_vars(python_path: &String) -> Result<HashMap<String, String>, String> {
+fn get_config_vars(python_path: &str) -> Result<HashMap<String, String>, String> {
     let mut script = "import sysconfig; \
                       config = sysconfig.get_config_vars();"
         .to_owned();
@@ -78,7 +78,7 @@ fn get_config_vars(python_path: &String) -> Result<HashMap<String, String>, Stri
             k,
             if is_value(k) { "None" } else { "0" }
         ));
-        script.push_str(";");
+        script.push(';');
     }
 
     let mut cmd = Command::new(python_path);
@@ -90,7 +90,7 @@ fn get_config_vars(python_path: &String) -> Result<HashMap<String, String>, Stri
 
     if !out.status.success() {
         let stderr = String::from_utf8(out.stderr).unwrap();
-        let mut msg = format!("python script failed with stderr:\n\n");
+        let mut msg = "python script failed with stderr:\n\n".to_string();
         msg.push_str(&stderr);
         return Err(msg);
     }
@@ -102,15 +102,14 @@ fn get_config_vars(python_path: &String) -> Result<HashMap<String, String>, Stri
             "python stdout len didn't return expected number of lines:
 {}",
             split_stdout.len()
-        )
-        .to_string());
+        ));
     }
     let all_vars = SYSCONFIG_FLAGS.iter().chain(SYSCONFIG_VALUES.iter());
     // let var_map: HashMap<String, String> = HashMap::new();
     Ok(all_vars.zip(split_stdout.iter()).fold(
         HashMap::new(),
         |mut memo: HashMap<String, String>, (&k, &v)| {
-            if !(v.to_owned() == "None" && is_value(k)) {
+            if !(v == "None" && is_value(k)) {
                 memo.insert(k.to_owned(), v.to_owned());
             }
             memo
@@ -119,7 +118,7 @@ fn get_config_vars(python_path: &String) -> Result<HashMap<String, String>, Stri
 }
 
 #[cfg(target_os = "windows")]
-fn get_config_vars(_: &String) -> Result<HashMap<String, String>, String> {
+fn get_config_vars(_: &str) -> Result<HashMap<String, String>, String> {
     // sysconfig is missing all the flags on windows, so we can't actually
     // query the interpreter directly for its build flags.
     //
@@ -148,7 +147,7 @@ fn get_config_vars(_: &String) -> Result<HashMap<String, String>, String> {
 }
 
 fn is_value(key: &str) -> bool {
-    SYSCONFIG_VALUES.iter().find(|x| **x == key).is_some()
+    SYSCONFIG_VALUES.iter().any(|x| *x == key)
 }
 
 fn cfg_line_for_var(key: &str, val: &str) -> Option<String> {
@@ -182,17 +181,17 @@ fn run_python_script(interpreter: &str, script: &str) -> Result<String, String> 
 
     if !out.status.success() {
         let stderr = String::from_utf8(out.stderr).unwrap();
-        let mut msg = format!("python script failed with stderr:\n\n");
+        let mut msg = "python script failed with stderr:\n\n".to_string();
         msg.push_str(&stderr);
         return Err(msg);
     }
 
-    let out = String::from_utf8(out.stdout).unwrap();
-    return Ok(out);
+    Ok(String::from_utf8(out.stdout).unwrap())
 }
 
 #[cfg(not(target_os = "macos"))]
 #[cfg(not(target_os = "windows"))]
+#[allow(clippy::unnecessary_wraps)]
 fn get_rustc_link_lib(
     _: &PythonVersion,
     ld_version: &str,
@@ -275,7 +274,7 @@ fn find_interpreter_and_get_config(
         let (executable, interpreter_version, lines) =
             get_config_from_interpreter(interpreter_path)?;
         if matching_version(expected_version, &interpreter_version) {
-            return Ok((interpreter_version, executable.to_owned(), lines));
+            return Ok((interpreter_version, executable, lines));
         } else {
             return Err(format!(
                 "Wrong python version in PYTHON_SYS_EXECUTABLE={}\n\
@@ -294,11 +293,11 @@ fn find_interpreter_and_get_config(
     }
 
     for name in possible_names.iter() {
-        if let Some((executable, interpreter_version, lines)) =
-            get_config_from_interpreter(name).ok()
+        if let Ok((executable, interpreter_version, lines)) =
+            get_config_from_interpreter(name)
         {
             if matching_version(expected_version, &interpreter_version) {
-                return Ok((interpreter_version, executable.to_owned(), lines));
+                return Ok((interpreter_version, executable, lines));
             }
         }
     }
@@ -368,20 +367,18 @@ fn configure_from_path(expected_version: &PythonVersion) -> Result<String, Strin
                 println!("cargo:rustc-link-search=native={}\\libs", exec_prefix);
             }
         }
-    } else if link_mode_unresolved_static {
-        if cfg!(target_os = "windows") {
-            // static-nobundle requires a Nightly rustc up to at least
-            // Rust 1.39 (https://github.com/rust-lang/rust/issues/37403).
-            //
-            // We need to use static linking on Windows to prevent symbol
-            // name mangling. Otherwise Rust will prefix extern {} symbols
-            // with __imp_. But if we used normal "static," we need a
-            // pythonXY.lib at build time to package into the rlib.
-            //
-            // static-nobundle removes the build-time library requirement,
-            // allowing a downstream consumer to provide the pythonXY library.
-            println!("cargo:rustc-link-lib=static-nobundle=pythonXY");
-        }
+    } else if link_mode_unresolved_static && cfg!(target_os = "windows") {
+        // static-nobundle requires a Nightly rustc up to at least
+        // Rust 1.39 (https://github.com/rust-lang/rust/issues/37403).
+        //
+        // We need to use static linking on Windows to prevent symbol
+        // name mangling. Otherwise Rust will prefix extern {} symbols
+        // with __imp_. But if we used normal "static," we need a
+        // pythonXY.lib at build time to package into the rlib.
+        //
+        // static-nobundle removes the build-time library requirement,
+        // allowing a downstream consumer to provide the pythonXY library.
+        println!("cargo:rustc-link-lib=static-nobundle=pythonXY");
     }
 
     if let PythonVersion {
@@ -399,7 +396,7 @@ fn configure_from_path(expected_version: &PythonVersion) -> Result<String, Strin
         }
     }
 
-    return Ok(interpreter_path);
+    Ok(interpreter_path)
 }
 
 /// Determine the python version we're supposed to be building
@@ -415,17 +412,11 @@ fn version_from_env() -> Result<PythonVersion, String> {
     let mut vars = env::vars().collect::<Vec<_>>();
     vars.sort_by(|a, b| b.cmp(a));
     for (key, _) in vars {
-        match re.captures(&key) {
-            Some(cap) => {
-                return Ok(PythonVersion {
-                    major: cap.get(1).unwrap().as_str().parse().unwrap(),
-                    minor: match cap.get(3) {
-                        Some(s) => Some(s.as_str().parse().unwrap()),
-                        None => None,
-                    },
-                })
-            }
-            None => (),
+        if let Some(cap) = re.captures(&key) {
+            return Ok(PythonVersion {
+                major: cap.get(1).unwrap().as_str().parse().unwrap(),
+                minor: cap.get(3).map(|s| s.as_str().parse().unwrap()),
+            });
         }
     }
     Err(
@@ -456,9 +447,8 @@ fn main() {
         config_map.insert("Py_REF_DEBUG".to_owned(), "1".to_owned()); // Py_TRACE_REFS implies Py_REF_DEBUG.
     }
     for (key, val) in &config_map {
-        match cfg_line_for_var(key, val) {
-            Some(line) => println!("{}", line),
-            None => (),
+        if let Some(line) = cfg_line_for_var(key, val) {
+            println!("{}", line);
         }
     }
 
@@ -486,7 +476,7 @@ fn main() {
     });
     println!(
         "cargo:python_flags={}",
-        if flags.len() > 0 {
+        if !flags.is_empty() {
             &flags[..flags.len() - 1]
         } else {
             ""

--- a/python3-sys/src/bytesobject.rs
+++ b/python3-sys/src/bytesobject.rs
@@ -24,8 +24,9 @@ extern "C" {
     pub fn PyBytes_FromStringAndSize(arg1: *const c_char, arg2: Py_ssize_t) -> *mut PyObject;
     pub fn PyBytes_FromString(arg1: *const c_char) -> *mut PyObject;
     pub fn PyBytes_FromObject(arg1: *mut PyObject) -> *mut PyObject;
-    //pub fn PyBytes_FromFormatV(arg1: *const c_char, arg2: va_list)
-    // -> *mut PyObject;
+    ignore! {
+        pub fn PyBytes_FromFormatV(arg1: *const c_char, arg2: va_list) -> *mut PyObject;
+    }
     pub fn PyBytes_FromFormat(arg1: *const c_char, ...) -> *mut PyObject;
     pub fn PyBytes_Size(arg1: *mut PyObject) -> Py_ssize_t;
     pub fn PyBytes_AsString(arg1: *mut PyObject) -> *mut c_char;

--- a/python3-sys/src/ceval.rs
+++ b/python3-sys/src/ceval.rs
@@ -47,8 +47,10 @@ extern "C" {
     pub fn Py_SetRecursionLimit(arg1: c_int) -> ();
     pub fn Py_GetRecursionLimit() -> c_int;
 
-    //fn _Py_CheckRecursiveCall(_where: *mut c_char) -> c_int;
-    //static mut _Py_CheckRecursionLimit: c_int;
+    ignore! {
+        fn _Py_CheckRecursiveCall(_where: *mut c_char) -> c_int;
+        static mut _Py_CheckRecursionLimit: c_int;
+    }
 
     #[cfg(Py_3_9)]
     pub fn Py_EnterRecursiveCall(_where: *const c_char) -> c_int;

--- a/python3-sys/src/code.rs
+++ b/python3-sys/src/code.rs
@@ -6,7 +6,9 @@ use crate::pyport::Py_ssize_t;
 
 #[cfg(Py_3_8)]
 #[repr(C)]
-pub struct _PyOpcache { _private: [u8; 0] }
+pub struct _PyOpcache {
+    _private: [u8; 0],
+}
 
 #[repr(C)]
 #[derive(Copy)]

--- a/python3-sys/src/compile.rs
+++ b/python3-sys/src/compile.rs
@@ -19,25 +19,25 @@ pub struct PyFutureFeatures {
 // We still have our version in pythonrun.rs
 
 #[cfg(not(Py_LIMITED_API))]
-pub const FUTURE_NESTED_SCOPES: &'static str = "nested_scopes";
+pub const FUTURE_NESTED_SCOPES: &str = "nested_scopes";
 #[cfg(not(Py_LIMITED_API))]
-pub const FUTURE_GENERATORS: &'static str = "generators";
+pub const FUTURE_GENERATORS: &str = "generators";
 #[cfg(not(Py_LIMITED_API))]
-pub const FUTURE_DIVISION: &'static str = "division";
+pub const FUTURE_DIVISION: &str = "division";
 #[cfg(not(Py_LIMITED_API))]
-pub const FUTURE_ABSOLUTE_IMPORT: &'static str = "absolute_import";
+pub const FUTURE_ABSOLUTE_IMPORT: &str = "absolute_import";
 #[cfg(not(Py_LIMITED_API))]
-pub const FUTURE_WITH_STATEMENT: &'static str = "with_statement";
+pub const FUTURE_WITH_STATEMENT: &str = "with_statement";
 #[cfg(not(Py_LIMITED_API))]
-pub const FUTURE_PRINT_FUNCTION: &'static str = "print_function";
+pub const FUTURE_PRINT_FUNCTION: &str = "print_function";
 #[cfg(not(Py_LIMITED_API))]
-pub const FUTURE_UNICODE_LITERALS: &'static str = "unicode_literals";
+pub const FUTURE_UNICODE_LITERALS: &str = "unicode_literals";
 #[cfg(not(Py_LIMITED_API))]
-pub const FUTURE_BARRY_AS_BDFL: &'static str = "barry_as_FLUFL";
+pub const FUTURE_BARRY_AS_BDFL: &str = "barry_as_FLUFL";
 #[cfg(all(not(Py_LIMITED_API), Py_3_5))]
-pub const FUTURE_GENERATOR_STOP: &'static str = "generator_stop";
+pub const FUTURE_GENERATOR_STOP: &str = "generator_stop";
 #[cfg(all(not(Py_LIMITED_API), Py_3_7))]
-pub const FUTURE_ANNOTATIONS: &'static str = "annotations";
+pub const FUTURE_ANNOTATIONS: &str = "annotations";
 
 #[cfg(not(Py_LIMITED_API))]
 #[cfg_attr(windows, link(name = "pythonXY"))]

--- a/python3-sys/src/fileobject.rs
+++ b/python3-sys/src/fileobject.rs
@@ -2,7 +2,7 @@ use libc::{c_char, c_int};
 
 use crate::object::PyObject;
 
-pub const PY_STDIOTEXTMODE: &'static str = "b";
+pub const PY_STDIOTEXTMODE: &str = "b";
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/python3-sys/src/frameobject.rs
+++ b/python3-sys/src/frameobject.rs
@@ -15,7 +15,9 @@ pub struct PyTryBlock {
 
 #[cfg(Py_LIMITED_API)]
 #[repr(C)]
-pub struct PyFrameObject { _private: [u8; 0] }
+pub struct PyFrameObject {
+    _private: [u8; 0],
+}
 
 #[cfg(not(Py_LIMITED_API))]
 #[repr(C)]

--- a/python3-sys/src/lib.rs
+++ b/python3-sys/src/lib.rs
@@ -3,7 +3,11 @@
     non_camel_case_types,
     non_snake_case,
     non_upper_case_globals,
-    unused_parens
+    unused_parens,
+    clippy::missing_safety_doc,
+    clippy::transmute_ptr_to_ptr,
+    clippy::unused_unit,
+    clippy::identity_op,
 )]
 #![cfg_attr(Py_LIMITED_API, allow(unused_imports))]
 

--- a/python3-sys/src/lib.rs
+++ b/python3-sys/src/lib.rs
@@ -7,7 +7,7 @@
     clippy::missing_safety_doc,
     clippy::transmute_ptr_to_ptr,
     clippy::unused_unit,
-    clippy::identity_op,
+    clippy::identity_op
 )]
 #![cfg_attr(Py_LIMITED_API, allow(unused_imports))]
 
@@ -17,6 +17,11 @@
 
 // new:
 // Based on the headers of Python 3.3.0, 3.4.0 and 3.5.0.
+
+// Macro for marking parts of the Python headers as ignored.
+macro_rules! ignore {
+    ( $( $_tokens:tt )* ) => {};
+}
 
 pub use crate::bltinmodule::*;
 pub use crate::boolobject::*;

--- a/python3-sys/src/longobject.rs
+++ b/python3-sys/src/longobject.rs
@@ -4,7 +4,9 @@ use crate::object::*;
 use crate::pyport::Py_ssize_t;
 
 #[repr(C)]
-pub struct PyLongObject { _private: [u8; 0] }
+pub struct PyLongObject {
+    _private: [u8; 0],
+}
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/python3-sys/src/modsupport.rs
+++ b/python3-sys/src/modsupport.rs
@@ -28,10 +28,10 @@ extern "C" {
         ...
     ) -> c_int;
     pub fn Py_BuildValue(arg1: *const c_char, ...) -> *mut PyObject;
-    //pub fn _Py_BuildValue_SizeT(arg1: *const c_char, ...)
-    // -> *mut PyObject;
-    //pub fn Py_VaBuildValue(arg1: *const c_char, arg2: va_list)
-    // -> *mut PyObject;
+    ignore! {
+        pub fn _Py_BuildValue_SizeT(arg1: *const c_char, ...) -> *mut PyObject;
+        pub fn Py_VaBuildValue(arg1: *const c_char, arg2: va_list) -> *mut PyObject;
+    }
     pub fn PyModule_AddObject(
         arg1: *mut PyObject,
         arg2: *const c_char,

--- a/python3-sys/src/object.rs
+++ b/python3-sys/src/object.rs
@@ -202,7 +202,9 @@ pub type vectorcallfunc = unsafe extern "C" fn(
 
 #[cfg(Py_LIMITED_API)]
 #[repr(C)]
-pub struct PyTypeObject { _private: [u8; 0] }
+pub struct PyTypeObject {
+    _private: [u8; 0],
+}
 
 #[cfg(not(Py_LIMITED_API))]
 mod typeobject {

--- a/python3-sys/src/pyarena.rs
+++ b/python3-sys/src/pyarena.rs
@@ -1,2 +1,4 @@
 #[repr(C)]
-pub struct PyArena { _private: [u8; 0] }
+pub struct PyArena {
+    _private: [u8; 0],
+}

--- a/python3-sys/src/pystate.rs
+++ b/python3-sys/src/pystate.rs
@@ -1,5 +1,3 @@
-use libc;
-
 #[cfg(Py_3_9)]
 use crate::frameobject::PyFrameObject;
 use crate::moduleobject::PyModuleDef;

--- a/python3-sys/src/pystate.rs
+++ b/python3-sys/src/pystate.rs
@@ -7,10 +7,14 @@ use crate::object::PyObject;
 pub const MAX_CO_EXTRA_USERS: libc::c_int = 255;
 
 #[repr(C)]
-pub struct PyInterpreterState { _private: [u8; 0] }
+pub struct PyInterpreterState {
+    _private: [u8; 0],
+}
 
 #[repr(C)]
-pub struct PyThreadState { _private: [u8; 0] }
+pub struct PyThreadState {
+    _private: [u8; 0],
+}
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
@@ -25,9 +29,10 @@ extern "C" {
     pub fn PyInterpreterState_GetID(arg1: *mut PyInterpreterState) -> i64;
     pub fn PyState_FindModule(arg1: *mut PyModuleDef) -> *mut PyObject;
     pub fn PyThreadState_New(arg1: *mut PyInterpreterState) -> *mut PyThreadState;
-    //fn _PyThreadState_Prealloc(arg1: *mut PyInterpreterState)
-    // -> *mut PyThreadState;
-    //fn _PyThreadState_Init(arg1: *mut PyThreadState) -> ();
+    ignore! {
+        fn _PyThreadState_Prealloc(arg1: *mut PyInterpreterState) -> *mut PyThreadState;
+        fn _PyThreadState_Init(arg1: *mut PyThreadState) -> ();
+    }
     pub fn PyThreadState_Clear(arg1: *mut PyThreadState) -> ();
     pub fn PyThreadState_Delete(arg1: *mut PyThreadState) -> ();
     #[cfg(any(Py_3_7, py_sys_config = "WITH_THREAD"))]

--- a/python3-sys/src/pythonrun.rs
+++ b/python3-sys/src/pythonrun.rs
@@ -38,8 +38,9 @@ pub struct PyCompilerFlags {
 
 #[cfg(not(Py_LIMITED_API))]
 #[repr(C)]
-pub struct _mod { _private: [u8; 0] }
-
+pub struct _mod {
+    _private: [u8; 0],
+}
 
 #[cfg(not(Py_LIMITED_API))]
 #[cfg_attr(windows, link(name = "pythonXY"))]
@@ -119,10 +120,14 @@ extern "C" {
 }
 
 #[repr(C)]
-pub struct symtable { _private: [u8; 0] }
+pub struct symtable {
+    _private: [u8; 0],
+}
 
 #[repr(C)]
-pub struct _node { _private: [u8; 0] }
+pub struct _node {
+    _private: [u8; 0],
+}
 
 #[inline]
 #[deprecated(since = "0.5.2", note = "Deprecated since Python 3.9")]

--- a/python3-sys/src/unicodeobject.rs
+++ b/python3-sys/src/unicodeobject.rs
@@ -1,9 +1,9 @@
 use libc::{c_char, c_int, c_void, wchar_t};
 
 use crate::object::*;
-use crate::pyport::Py_ssize_t;
 #[cfg(not(Py_LIMITED_API))]
 use crate::pyport::Py_hash_t;
+use crate::pyport::Py_ssize_t;
 
 #[cfg(not(Py_LIMITED_API))]
 #[deprecated(since = "0.2.1", note = "Deprecated since Python 3.3 / PEP 393")]
@@ -106,8 +106,9 @@ extern "C" {
         errors: *const c_char,
     ) -> *mut PyObject;
     pub fn PyUnicode_FromObject(obj: *mut PyObject) -> *mut PyObject;
-    //pub fn PyUnicode_FromFormatV(format: *const c_char,
-    //                             vargs: va_list) -> *mut PyObject;
+    ignore! {
+        pub fn PyUnicode_FromFormatV(format: *const c_char, vargs: va_list) -> *mut PyObject;
+    }
     pub fn PyUnicode_FromFormat(format: *const c_char, ...) -> *mut PyObject;
     pub fn PyUnicode_InternInPlace(arg1: *mut *mut PyObject) -> ();
     pub fn PyUnicode_InternImmortal(arg1: *mut *mut PyObject) -> ();
@@ -443,7 +444,7 @@ pub struct PyASCIIObject {
     pub length: Py_ssize_t,
     pub hash: Py_hash_t,
     pub state: u32,
-    pub wstr: *mut c_void
+    pub wstr: *mut c_void,
 }
 
 #[repr(C)]
@@ -452,14 +453,14 @@ pub struct PyCompactUnicodeObject {
     _base: PyASCIIObject,
     utf8_length: Py_ssize_t,
     utf8: *mut u8,
-    wstr_length: Py_ssize_t
+    wstr_length: Py_ssize_t,
 }
 
 #[repr(C)]
 #[cfg(not(Py_LIMITED_API))]
 pub struct PyUnicodeObject {
     _base: PyASCIIObject,
-    data: *mut c_void
+    data: *mut c_void,
 }
 
 #[cfg(not(Py_LIMITED_API))]
@@ -502,7 +503,7 @@ pub unsafe fn PyUnicode_DATA(o: *mut PyObject) -> *mut c_void {
     debug_assert!(PyUnicode_IS_READY(o));
     if PyUnicode_IS_COMPACT(o) {
         // fn _PyUnicode_COMPACT_DATA
-         if PyUnicode_IS_ASCII(o) {
+        if PyUnicode_IS_ASCII(o) {
             (o as *mut PyASCIIObject).offset(1) as *mut c_void
         } else {
             (o as *mut PyCompactUnicodeObject).offset(1) as *mut c_void

--- a/python3-sys/src/weakrefobject.rs
+++ b/python3-sys/src/weakrefobject.rs
@@ -3,7 +3,9 @@ use libc::c_int;
 use crate::object::*;
 
 #[repr(C)]
-pub struct PyWeakReference { _private: [u8; 0] }
+pub struct PyWeakReference {
+    _private: [u8; 0],
+}
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -16,7 +16,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use libc;
 use std::ffi::CStr;
 use std::{cell, mem, slice};
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -16,7 +16,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use libc;
 use libc::c_char;
 use std::ffi::CString;
 use std::ptr;

--- a/src/function.rs
+++ b/src/function.rs
@@ -16,7 +16,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use libc;
 use std::ffi::{CStr, CString};
 use std::panic;
 use std::{any, io, marker, mem, ptr};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 #![cfg_attr(feature="nightly", feature(
-    const_fn, // for GILProtected::new (#24111)
     specialization, // for impl FromPyObject<'s> for Vec<...> (#31844)
 ))]
 #![allow(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,12 @@
     const_fn, // for GILProtected::new (#24111)
     specialization, // for impl FromPyObject<'s> for Vec<...> (#31844)
 ))]
-#![allow(unused_imports)] // because some imports are only necessary with python 2.x or 3.x
+#![allow(
+    unused_imports, // because some imports are only necessary with python 2.x or 3.x
+    clippy::missing_safety_doc,
+    clippy::manual_strip,
+    clippy::match_like_matches_macro
+)]
 
 //! Rust bindings to the Python interpreter.
 //!

--- a/src/objectprotocol.rs
+++ b/src/objectprotocol.rs
@@ -16,7 +16,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use libc;
 use std::cmp::Ordering;
 use std::fmt;
 
@@ -106,13 +105,7 @@ pub trait ObjectProtocol: PythonObject {
         ) -> PyResult<Ordering> {
             let mut result = -1;
             err::error_on_minusone(py, ffi::PyObject_Cmp(a, b, &mut result))?;
-            Ok(if result < 0 {
-                Ordering::Less
-            } else if result > 0 {
-                Ordering::Greater
-            } else {
-                Ordering::Equal
-            })
+            Ok(result.cmp(&0))
         }
 
         #[cfg(feature = "python3-sys")]
@@ -139,10 +132,10 @@ pub trait ObjectProtocol: PythonObject {
             } else if result < 0 {
                 return Err(PyErr::fetch(py));
             }
-            return Err(PyErr::new::<crate::exc::TypeError, _>(
+            Err(PyErr::new::<crate::exc::TypeError, _>(
                 py,
                 "ObjectProtocol::compare(): All comparisons returned false",
-            ));
+            ))
         }
 
         other.with_borrowed_ptr(py, |other| unsafe { do_compare(py, self.as_ptr(), other) })

--- a/src/objects/iterator.rs
+++ b/src/objects/iterator.rs
@@ -38,7 +38,7 @@ impl<'p> PyIterator<'p> {
         obj: PyObject,
     ) -> Result<PyIterator<'p>, PythonObjectDowncastError<'p>> {
         if unsafe { ffi::PyIter_Check(obj.as_ptr()) != 0 } {
-            Ok(PyIterator { py: py, iter: obj })
+            Ok(PyIterator { py, iter: obj })
         } else {
             Err(PythonObjectDowncastError::new(
                 py,

--- a/src/objects/list.rs
+++ b/src/objects/list.rs
@@ -95,7 +95,7 @@ impl PyList {
     #[inline]
     pub fn iter<'a, 'p>(&'a self, py: Python<'p>) -> PyListIterator<'a, 'p> {
         PyListIterator {
-            py: py,
+            py,
             list: self,
             index: 0,
         }

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -16,6 +16,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#![allow(clippy::transmute_ptr_to_ptr)]
+
 pub use self::module::PyModule;
 pub use self::object::PyObject;
 pub use self::typeobject::PyType;

--- a/src/objects/module.rs
+++ b/src/objects/module.rs
@@ -80,7 +80,7 @@ impl PyModule {
     ///
     /// May fail if the module does not have a `__file__` attribute.
     #[allow(deprecated)]
-    pub fn filename<'a>(&'a self, py: Python) -> PyResult<&'a str> {
+    pub fn filename(&self, py: Python) -> PyResult<&str> {
         unsafe { self.str_from_ptr(py, ffi::PyModule_GetFilename(self.0.as_ptr())) }
     }
 
@@ -88,7 +88,7 @@ impl PyModule {
     ///
     /// May fail if the module does not have a `__file__` attribute.
     #[cfg(feature = "python3-sys")]
-    pub fn filename_object<'a>(&'a self, py: Python) -> PyResult<PyObject> {
+    pub fn filename_object(&self, py: Python) -> PyResult<PyObject> {
         let ptr = unsafe { ffi::PyModule_GetFilenameObject(self.0.as_ptr()) };
         if ptr.is_null() {
             Err(PyErr::fetch(py))
@@ -151,7 +151,7 @@ impl PyModule {
     /// This is a convenience function that initializes the `py_class!()`,
     /// sets `new_type.__module__` to this module's name,
     /// and adds the type to this module.
-    pub fn add_class<'p, T>(&self, py: Python<'p>) -> PyResult<()>
+    pub fn add_class<T>(&self, py: Python<'_>) -> PyResult<()>
     where
         T: PythonObjectFromPyClassMacro,
     {

--- a/src/objects/num.rs
+++ b/src/objects/num.rs
@@ -16,6 +16,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#![allow(clippy::float_cmp)]
+
 use libc::{c_double, c_long};
 use num_traits::cast::cast;
 
@@ -174,7 +176,7 @@ macro_rules! int_fits_larger_int(
     )
 );
 
-fn err_if_invalid_value<'p, T: PartialEq>(
+fn err_if_invalid_value<T: PartialEq>(
     py: Python,
     invalid_value: T,
     actual_value: T,

--- a/src/objects/object.rs
+++ b/src/objects/object.rs
@@ -91,10 +91,10 @@ impl PythonObject for PyObject {
 
 impl PythonObjectWithCheckedDowncast for PyObject {
     #[inline]
-    fn downcast_from<'p>(
-        _py: Python<'p>,
+    fn downcast_from(
+        _py: Python<'_>,
         obj: PyObject,
-    ) -> Result<PyObject, PythonObjectDowncastError<'p>> {
+    ) -> Result<PyObject, PythonObjectDowncastError<'_>> {
         Ok(obj)
     }
 
@@ -180,7 +180,7 @@ impl PyObject {
     /// Transmutes an FFI pointer to `&PyObject`.
     /// Undefined behavior if the pointer is NULL or invalid.
     #[inline]
-    pub unsafe fn borrow_from_ptr<'a>(ptr: &'a *mut ffi::PyObject) -> &'a PyObject {
+    pub unsafe fn borrow_from_ptr(ptr: &*mut ffi::PyObject) -> &PyObject {
         debug_assert!(!ptr.is_null());
         mem::transmute(ptr)
     }
@@ -188,7 +188,7 @@ impl PyObject {
     /// Transmutes a slice of owned FFI pointers to `&[PyObject]`.
     /// Undefined behavior if any pointer in the slice is NULL or invalid.
     #[inline]
-    pub unsafe fn borrow_from_owned_ptr_slice<'a>(ptr: &'a [*mut ffi::PyObject]) -> &'a [PyObject] {
+    pub unsafe fn borrow_from_owned_ptr_slice(ptr: &[*mut ffi::PyObject]) -> &[PyObject] {
         mem::transmute(ptr)
     }
 
@@ -218,7 +218,7 @@ impl PyObject {
     /// Fails with `PythonObjectDowncastError` if the object is not of the expected type.
     /// This is a wrapper function around `PythonObjectWithCheckedDowncast::downcast_from()`.
     #[inline]
-    pub fn cast_into<'p, T>(self, py: Python<'p>) -> Result<T, PythonObjectDowncastError<'p>>
+    pub fn cast_into<T>(self, py: Python<'_>) -> Result<T, PythonObjectDowncastError<'_>>
     where
         T: PythonObjectWithCheckedDowncast,
     {
@@ -229,7 +229,7 @@ impl PyObject {
     /// Causes undefined behavior if the object is not of the expected type.
     /// This is a wrapper function around `PythonObject::unchecked_downcast_borrow_from()`.
     #[inline]
-    pub unsafe fn unchecked_cast_as<'s, T>(&'s self) -> &'s T
+    pub unsafe fn unchecked_cast_as<T>(&self) -> &T
     where
         T: PythonObject,
     {

--- a/src/objects/set.rs
+++ b/src/objects/set.rs
@@ -170,7 +170,7 @@ mod test {
         let mut v = HashSet::new();
         v.insert(7);
         let set = v.to_py_object(py);
-        assert!(true, set.contains(py, 7i32).unwrap());
+        assert_eq!(true, set.contains(py, 7i32).unwrap());
         assert_eq!(false, set.contains(py, 8i32).unwrap());
     }
 

--- a/src/py_class/gc.rs
+++ b/src/py_class/gc.rs
@@ -16,7 +16,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use libc;
 use std::mem;
 
 use crate::ffi;
@@ -103,8 +102,8 @@ where
     let guard = AbortOnDrop(location);
     let py = Python::assume_gil_acquired();
     let visit = VisitProc {
-        visit: visit,
-        arg: arg,
+        visit,
+        arg,
         _py: py,
     };
     let slf = PyObject::from_borrowed_ptr(py, slf).unchecked_cast_into::<C>();

--- a/src/pythonrun.rs
+++ b/src/pythonrun.rs
@@ -160,15 +160,7 @@ unsafe impl<T: Send> Sync for GILProtected<T> {}
 impl<T> GILProtected<T> {
     /// Creates a new instance of `GILProtected`.
     #[inline]
-    #[cfg(feature = "nightly")]
     pub const fn new(data: T) -> GILProtected<T> {
-        GILProtected { data: data }
-    }
-
-    /// Creates a new instance of `GILProtected`.
-    #[inline]
-    #[cfg(not(feature = "nightly"))]
-    pub fn new(data: T) -> GILProtected<T> {
         GILProtected { data }
     }
 

--- a/src/pythonrun.rs
+++ b/src/pythonrun.rs
@@ -118,14 +118,14 @@ impl GILGuard {
         }
         let gstate = unsafe { ffi::PyGILState_Ensure() }; // acquire GIL
         GILGuard {
-            gstate: gstate,
+            gstate,
             no_send: marker::PhantomData,
         }
     }
 
     /// Retrieves the marker type that proves that the GIL was acquired.
     #[inline]
-    pub fn python<'p>(&'p self) -> Python<'p> {
+    pub fn python(&self) -> Python<'_> {
         unsafe { Python::assume_gil_acquired() }
     }
 }
@@ -169,7 +169,7 @@ impl<T> GILProtected<T> {
     #[inline]
     #[cfg(not(feature = "nightly"))]
     pub fn new(data: T) -> GILProtected<T> {
-        GILProtected { data: data }
+        GILProtected { data }
     }
 
     /// Returns a shared reference to the data stored in the `GILProtected`.

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -59,7 +59,7 @@ impl<'gil> Deserializer<'gil> {
                 //
                 // Special case: for PyDict, call the "items" method first to get
                 // an iterator of (key, value) instead of just keys.
-                let iter = if let Ok(_) = self.extract::<PyDict>() {
+                let iter = if self.extract::<PyDict>().is_ok() {
                     let items = self.obj.call_method(self.py, "items", NoArgs, None)?;
                     items.iter(self.py)?
                 } else {
@@ -99,9 +99,7 @@ impl<'de, 'a, 'gil> de::Deserializer<'de> for &'a mut Deserializer<'gil> {
             self.deserialize_bool(v)
         } else if self.extract::<PyDict>().is_ok() {
             self.deserialize_map(v)
-        } else if self.extract::<PyList>().is_ok() {
-            self.deserialize_seq(v)
-        } else if self.extract::<PyTuple>().is_ok() {
+        } else if self.extract::<PyList>().is_ok() || self.extract::<PyTuple>().is_ok() {
             self.deserialize_seq(v)
         } else if self.extract::<PyBytes>().is_ok() {
             self.deserialize_bytes(v)

--- a/src/serde/error.rs
+++ b/src/serde/error.rs
@@ -23,7 +23,7 @@ impl fmt::Display for Error {
             .0
             .pvalue
             .as_ref()
-            .unwrap_or_else(|| &self.0.ptype)
+            .unwrap_or(&self.0.ptype)
             .repr(py)
             .map(|s| s.to_string_lossy(py).to_string())
             .unwrap_or_else(|_| "<error in repr>".into());

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -108,10 +108,12 @@ impl PyCollectItems for BuildDict {
 // ------- Serde APIs -------
 
 impl<'a> Serializer<'a> {
+    #[allow(clippy::unnecessary_wraps)]
     fn serialize<T: ToPyObject>(&self, obj: T) -> Result<PyObject> {
         Ok(obj.into_py_object(self.py).into_object())
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn to_object<T: Serialize + ?Sized>(py: Python, value: &T) -> Result<PyObject> {
         let serializer = Serializer { py };
         value.serialize(&serializer)

--- a/src/sharedref.rs
+++ b/src/sharedref.rs
@@ -126,8 +126,8 @@ impl<'a, T: ?Sized> PySharedRef<'a, T> {
     #[doc(hidden)]
     pub unsafe fn new(py: Python<'a>, owner: &'a PyObject, data: &'a PySharedRefCell<T>) -> Self {
         Self {
-            py: py,
-            owner: owner,
+            py,
+            owner,
             state: &data.state,
             data: &data.data,
         }

--- a/tests/test_class.rs
+++ b/tests/test_class.rs
@@ -28,7 +28,7 @@ macro_rules! py_expect_exception {
         let res = $py.run($code, None, Some(&d));
         let err = res.unwrap_err();
         if !err.matches($py, $py.get_type::<exc::$err>()) {
-            panic!(format!("Expected {} but got {:?}", stringify!($err), err))
+            panic!("Expected {} but got {:?}", stringify!($err), err)
         }
     }};
 }


### PR DESCRIPTION
Fix or suppress all warnings, including clippy lints.  A new `make clippy` target is added to run clippy.

Reformat using the latest versions of `rustfmt`.

There were some formatting conflicts caused by the commented out prototypes in the `sys` crates.  I have switched these to using an `ignore!` macro so that they can be formatted better, and also makes it clearer what's happening.