### PR TITLE
Add GILGuard::check()

### DIFF
--- a/python3-sys/src/pystate.rs
+++ b/python3-sys/src/pystate.rs
@@ -62,6 +62,8 @@ pub enum PyGILState_STATE {
 #[cfg(any(Py_3_7, py_sys_config = "WITH_THREAD"))]
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
+    #[cfg(Py_3_4)]
+    pub fn PyGILState_Check() -> libc::c_int;
     pub fn PyGILState_Ensure() -> PyGILState_STATE;
     pub fn PyGILState_Release(arg1: PyGILState_STATE) -> ();
     pub fn PyGILState_GetThisThreadState() -> *mut PyThreadState;

--- a/src/pythonrun.rs
+++ b/src/pythonrun.rs
@@ -128,6 +128,13 @@ impl GILGuard {
     pub fn python(&self) -> Python<'_> {
         unsafe { Python::assume_gil_acquired() }
     }
+
+    /// Checks if the current thread holds the GIL.
+    #[cfg(Py_3_4)]
+    pub fn check() -> bool {
+        let gstate = unsafe { ffi::PyGILState_Check() };
+        gstate == 1
+    }
 }
 
 /// Mutex-like wrapper object for data that is protected by the Python GIL.


### PR DESCRIPTION
Adds a function that returns true if the GIL is currently held for the
current thread.

When working with py.allow_threads(...) it is useful for the inner code
to be able to verify the GIL is not held in case it needs to acquire the
GIL on other threads. Being able to check this can help prevent
accidental deadlocks.

Ideally this could be done via static typing, similar to how the 'py'
object ensures the GIL is held, but I couldn't think of a clever way to
achieve this.