### PR TITLE
Fix macOS description of the example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ pub mod _detail {
 /// ```bash
 /// cp ./target/debug/libhello.so ./hello.so
 /// ```
-/// (Note: on Mac OS you will have to rename `libhello.dynlib` to `libhello.so`)
+/// (Note: on Mac OS you will have to rename `libhello.dynlib` to `hello.so`)
 ///
 /// The extension module can then be imported into Python:
 ///


### PR DESCRIPTION
It seems extra`lib` in front of `hello.so` is not needed on macOS either. At least I had to remove it to make it work as expected.