### PR TITLE
Initial support for Python 3.11 beta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ py-link-mode-unresolved-static = [ "python3-sys/link-mode-unresolved-static" ]
 # Optional features to support explicitly specifying python minor version.
 # If you don't care which minor version, just specify python3-sys as a 
 # feature.
+python-3-11 = ["python3-sys/python-3-11"]
 python-3-10 = ["python3-sys/python-3-10"]
 python-3-9 = ["python3-sys/python-3-9"]
 python-3-8 = ["python3-sys/python-3-8"]

--- a/python3-sys/Cargo.toml
+++ b/python3-sys/Cargo.toml
@@ -73,6 +73,7 @@ python-3-7 = []
 python-3-8 = []
 python-3-9 = []
 python-3-10 = []
+python-3-11 = []
 
 # Restrict to PEP-384 stable ABI
 pep-384 = []

--- a/python3-sys/src/code.rs
+++ b/python3-sys/src/code.rs
@@ -9,17 +9,44 @@ use crate::pyport::Py_ssize_t;
 pub struct _PyOpcache {
     _private: [u8; 0],
 }
+
 #[derive(Copy)]
 #[repr(C)]
-#[cfg(Py_3_11)] 
+#[cfg(Py_3_11)]
+// The field orderings have completely changed in 3.11,
+// so we seperate it out into a different type declaration
+// 
+// the justification for the reordering was "optimization"
 pub struct PyCodeObject {
-    _private: [u8; 0],
+    pub ob_base: PyObject,
+    pub co_consts: *mut PyObject,
+    pub co_names: *mut PyObject,
+    pub co_exceptiontable: *mut PyObject,
+    pub co_flags: c_int,
+    pub co_warmup: c_int,
+    pub co_argcount: c_int,
+    pub co_posonlyargcount: c_int,
+    pub co_kwonlyargcount: c_int,
+    pub co_stacksize: c_int,
+    pub co_firstlineno: c_int,
+    pub co_nlocalsplus: c_int,
+    pub co_nlocals: c_int,
+    pub co_nplaincellvars: c_int,
+    pub co_ncellvars: c_int,
+    pub co_nfreevars: c_int,
+    pub co_localsplusnames: *mut PyObject,
+    pub co_localspluskinds: *mut PyObject,
+    pub co_filename: *mut PyObject,
+    pub co_name: *mut PyObject,
+    pub co_qualname: *mut PyObject,
+    pub co_linetable: *mut PyObject,
+    pub co_weakreflist: *mut PyObject,
+    pub co_extra: *mut c_void,
+    pub co_code_adaptive: [c_char; 1],
 }
 
 #[repr(C)]
 #[derive(Copy)]
-// So many fields (and there orderings) have changed in 3.11,
-// it's best to just make it opaque
 #[cfg(not(Py_3_11))] 
 pub struct PyCodeObject {
     pub ob_base: PyObject,

--- a/python3-sys/src/frameobject.rs
+++ b/python3-sys/src/frameobject.rs
@@ -1,4 +1,6 @@
 use libc::{c_schar, c_int};
+#[cfg(not(Py_3_11))]
+use libc::c_char;
 
 use crate::code::{PyCodeObject};
 #[cfg(not(Py_3_11))]

--- a/python3-sys/src/frameobject.rs
+++ b/python3-sys/src/frameobject.rs
@@ -1,6 +1,8 @@
-use libc::{c_char, c_schar, c_int};
+use libc::{c_schar, c_int};
 
-use crate::code::{PyCodeObject, CO_MAXBLOCKS};
+use crate::code::{PyCodeObject};
+#[cfg(not(Py_3_11))]
+use crate::code::CO_MAXBLOCKS;
 use crate::object::*;
 use crate::pystate::PyThreadState;
 
@@ -16,13 +18,17 @@ pub struct PyTryBlock {
     pub b_level: c_int,
 }
 
-#[cfg(Py_LIMITED_API)]
+/// In Python > 3.11, frame object internals are always private
+///
+/// This improves performance by creating frame object lazily.
+/// There are now getter methods to get info from the frame.
+#[cfg(any(Py_LIMITED_API, Py_3_11))]
 #[repr(C)]
 pub struct PyFrameObject {
     _private: [u8; 0],
 }
 
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(all(not(Py_LIMITED_API), not(Py_3_11)))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyFrameObject {
@@ -98,12 +104,14 @@ extern "C" {
         locals: *mut PyObject,
     ) -> *mut PyFrameObject;
 
+    #[cfg(not(Py_3_11))]
     pub fn PyFrame_BlockSetup(
         f: *mut PyFrameObject,
         _type: c_int,
         handler: c_int,
         level: c_int,
     ) -> ();
+    #[cfg(not(Py_3_11))]
     pub fn PyFrame_BlockPop(f: *mut PyFrameObject) -> *mut PyTryBlock;
 
     pub fn PyFrame_LocalsToFast(f: *mut PyFrameObject, clear: c_int) -> ();
@@ -113,7 +121,26 @@ extern "C" {
 
     #[cfg(not(Py_3_9))]
     pub fn PyFrame_ClearFreeList() -> c_int;
-}
+
+    #[cfg(Py_3_9)]
+    pub fn PyFrame_GetBack(frame: *mut PyFrameObject) -> *mut PyFrameObject;
+
+    #[cfg(Py_3_11)]
+    pub fn PyFrame_GetBuiltins(frame: *mut PyFrameObject) -> *mut PyObject;
+
+    #[cfg(Py_3_11)]
+    pub fn PyFrame_GetGenerator(frame: *mut PyFrameObject) -> *mut PyObject;
+
+
+    #[cfg(Py_3_11)]
+    pub fn PyFrame_GetGlobals(frame: *mut PyFrameObject) -> *mut PyObject;
+
+   #[cfg(Py_3_11)]
+    pub fn PyFrame_GetLasti(frame: *mut PyFrameObject) -> c_int;
+
+   #[cfg(Py_3_11)]
+    pub fn PyFrame_GetLocals(frame: *mut PyFrameObject) -> *mut PyObject;
+}   
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/python3-sys/src/object.rs
+++ b/python3-sys/src/object.rs
@@ -746,6 +746,12 @@ extern "C" {
 
     #[cfg(Py_3_9)]
     pub fn PyType_GetModuleState(arg1: *mut PyTypeObject) -> *mut c_void;
+
+    #[cfg(Py_3_11)]
+    pub fn PyType_GetName(arg1: *mut PyTypeObject) -> *mut PyObject;
+
+    #[cfg(Py_3_11)]
+    pub fn PyType_GetQualName(arg1: *mut PyTypeObject) -> *mut PyObject;
 }
 
 #[cfg_attr(windows, link(name = "pythonXY"))]

--- a/python3-sys/src/pyerrors.rs
+++ b/python3-sys/src/pyerrors.rs
@@ -21,6 +21,9 @@ extern "C" {
         arg2: *mut *mut PyObject,
         arg3: *mut *mut PyObject,
     ) -> ();
+    #[cfg(Py_3_11)]
+    pub fn PyErr_GetHandledException() -> *mut PyObject;
+    pub fn PyErr_SetHandledException(exc: *mut PyObject);
     pub fn PyErr_SetExcInfo(arg1: *mut PyObject, arg2: *mut PyObject, arg3: *mut PyObject) -> ();
     pub fn Py_FatalError(message: *const c_char) -> !;
     pub fn PyErr_GivenExceptionMatches(arg1: *mut PyObject, arg2: *mut PyObject) -> c_int;

--- a/python3-sys/src/pystate.rs
+++ b/python3-sys/src/pystate.rs
@@ -46,6 +46,10 @@ extern "C" {
     pub fn PyThreadState_SetAsyncExc(arg1: libc::c_ulong, arg2: *mut PyObject) -> libc::c_int;
     #[cfg(Py_3_9)]
     pub fn PyThreadState_GetInterpreter(tstate: *mut PyThreadState) -> *mut PyInterpreterState;
+    #[cfg(Py_3_11)]
+    pub fn PyThreadState_EnterTracing(state: *mut PyThreadState);
+        #[cfg(Py_3_11)]
+    pub fn PyThreadState_LeaveTracing(state: *mut PyThreadState);
     #[cfg(Py_3_9)]
     pub fn PyThreadState_GetFrame(tstate: *mut PyThreadState) -> *mut PyFrameObject;
     #[cfg(Py_3_9)]


### PR DESCRIPTION
This is obviously experimental but it works okay.

All the tests pass and the example prints the following:

> $ cargo run --example hello --features python-3-11
> Hello nicholas, I'm Python 3.11.0b1 (v3.11.0b1:8d32a5c8c4, May  6 2022, 22:45:29) [Clang 13.0.0 (clang-1300.0.29.30)]

I figure it's best to be proactive with these change, so that way we are ready as soon as 3.11 proper is released (October I think).

MAin difference in 3.11 that frame object is now private (and lazy loaded).
This results in a performance improvement but makes it harder for debuggers.
Also the internal ordering of code objects has completely changed as well.
