### PR TITLE
Eliminate warnings on an unused `py`

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -152,8 +152,11 @@ macro_rules! py_fn_impl {
         }
     }};
     // Form 2: inline function definition
-    { $py:ident, $f:ident, $ret:ty, $body:block [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ] } => {{
-        fn $f($py: $crate::Python $( , $pname : $ptype )* ) -> $ret $body
+    { $py:ident, $f:ident, $ret:ty, {$($body:tt)*} [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ] } => {{
+        fn $f($py: $crate::Python $( , $pname : $ptype )* ) -> $ret {
+            let _ = $py;
+            $($body)*
+        }
         $crate::py_fn_impl!($py, $f [ $( { $pname : $ptype = $detail } )* ])
     }}
 }

--- a/src/py_class/py_class.rs
+++ b/src/py_class/py_class.rs
@@ -542,11 +542,14 @@ macro_rules! py_class {
 #[doc(hidden)]
 macro_rules! py_class_impl_item {
     { $class:ident, $py:ident, $visibility:vis, $name:ident( $( $selfarg:tt )* )
-        $res_type:ty; $body:block [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]
+        $res_type:ty; {$($body:tt)*} [ $( { $pname:ident : $ptype:ty = $detail:tt } )* ]
     } => { $crate::py_coerce_item! {
         impl $class {
             $visibility fn $name($( $selfarg )* $py: $crate::Python $( , $pname: $ptype )* )
-            -> $res_type $body
+            -> $res_type {
+                let _ = $py;
+                $($body)*
+            }
         }
     }}
 }

--- a/src/py_class/py_class_impl.py
+++ b/src/py_class/py_class_impl.py
@@ -470,7 +470,7 @@ def generate_class_method(special_name=None, decoration='',
             impl(with_params, with_docs, with_visibility)
 
 def traverse_and_clear():
-    generate_case('def __traverse__(&$slf:tt, $visit:ident) $body:block',
+    generate_case('def __traverse__(&$slf:tt, $visit:ident) {$($body:tt)*}',
         old_info = '''
         /* info: */ {
             $base_type: ty,
@@ -501,17 +501,22 @@ def traverse_and_clear():
                     fn __traverse__(&$slf,
                         $py: $crate::Python,
                         $visit: $crate::py_class::gc::VisitProc)
-                    -> Result<(), $crate::py_class::gc::TraverseError>
-                    $body
+                    -> Result<(), $crate::py_class::gc::TraverseError> {
+                        let _ = $py;
+                        $($body)*
+                    }
                 }
             }
         ''')
-    generate_case('def __clear__ (&$slf:ident) $body:block',
+    generate_case('def __clear__ (&$slf:ident) {$($body:tt)*}',
         new_slots=[('tp_clear', '$crate::py_class_tp_clear!($class)')],
         new_impl='''
             $crate::py_coerce_item!{
                 impl $class {
-                    fn __clear__(&$slf, $py: $crate::Python) $body
+                    fn __clear__(&$slf, $py: $crate::Python) {
+                        let _ = $py;
+                        $($body)*
+                    }
                 }
             }
         ''')

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -296,7 +296,7 @@ macro_rules! py_class_impl {
         }
         $members $props
     }};
-    { { def __traverse__(&$slf:tt, $visit:ident) $body:block $($tail:tt)* }
+    { { def __traverse__(&$slf:tt, $visit:ident) {$($body:tt)*} $($tail:tt)* }
         $class:ident $py:ident
         /* info: */ {
             $base_type: ty,
@@ -332,14 +332,16 @@ macro_rules! py_class_impl {
                     fn __traverse__(&$slf,
                     $py: $crate::Python,
                     $visit: $crate::py_class::gc::VisitProc)
-                    -> Result<(), $crate::py_class::gc::TraverseError>
-                    $body
+                    -> Result<(), $crate::py_class::gc::TraverseError> {
+                        let _ = $py;
+                        $($body)*
+                    }
                 }
             }
         }
         $members $props
     }};
-    { { def __clear__ (&$slf:ident) $body:block $($tail:tt)* }
+    { { def __clear__ (&$slf:ident) {$($body:tt)*} $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
@@ -361,7 +363,10 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_coerce_item!{
                 impl $class {
-                    fn __clear__(&$slf, $py: $crate::Python) $body
+                    fn __clear__(&$slf, $py: $crate::Python) {
+                        let _ = $py;
+                        $($body)*
+                    }
                 }
             }
         }

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -296,7 +296,7 @@ macro_rules! py_class_impl {
         }
         $members $props
     }};
-    { { def __traverse__(&$slf:tt, $visit:ident) $body:block $($tail:tt)* }
+    { { def __traverse__(&$slf:tt, $visit:ident) {$($body:tt)*} $($tail:tt)* }
         $class:ident $py:ident
         /* info: */ {
             $base_type: ty,
@@ -332,14 +332,16 @@ macro_rules! py_class_impl {
                     fn __traverse__(&$slf,
                     $py: $crate::Python,
                     $visit: $crate::py_class::gc::VisitProc)
-                    -> Result<(), $crate::py_class::gc::TraverseError>
-                    $body
+                    -> Result<(), $crate::py_class::gc::TraverseError> {
+                        let _ = $py;
+                        $($body)*
+                    }
                 }
             }
         }
         $members $props
     }};
-    { { def __clear__ (&$slf:ident) $body:block $($tail:tt)* }
+    { { def __clear__ (&$slf:ident) {$($body:tt)*} $($tail:tt)* }
         $class:ident $py:ident $info:tt
         /* slots: */ {
             /* type_slots */ [ $( $tp_slot_name:ident : $tp_slot_value:expr, )* ]
@@ -361,7 +363,10 @@ macro_rules! py_class_impl {
             $($imp)*
             $crate::py_coerce_item!{
                 impl $class {
-                    fn __clear__(&$slf, $py: $crate::Python) $body
+                    fn __clear__(&$slf, $py: $crate::Python) {
+                        let _ = $py;
+                        $($body)*
+                    }
                 }
             }
         }


### PR DESCRIPTION
Sometimes the `py` parameter of `py_class!` is only used in some class methods and not others. The current implementation of cpython's macros makes Rust produce a warning in this situation, which does not seem good.

Repro:

```rust
use cpython::{py_class, PyResult};

py_class!(class Struct |py| {
    data number: i32;
    def __new__(_cls, n: i32) -> PyResult<Struct> {
        Struct::create_instance(py, n)
    }
    def get_number(&self) -> PyResult<i32> {
        Ok(*self.number(py))
    }
    def get_random(&self) -> PyResult<i32> {
        Ok(4)
    }
});
```

### Before:

```console
warning: unused variable: `py`
 --> src/lib.rs:3:25
  |
3 | py_class!(class Struct |py| {
  |                         ^^ help: if this is intentional, prefix it with an underscore: `_py`
   |
  = note: `#[warn(unused_variables)]` on by default
```

Following the compiler's suggested fix causes the code not to build.

```console
error[E0425]: cannot find value `py` in this scope
 --> src/lib.rs:6:33
  |
6 |         Struct::create_instance(py, n)
  |                                 ^^ help: a local variable with a similar name exists: `_py`

error[E0425]: cannot find value `py` in this scope
 --> src/lib.rs:9:25
  |
9 |         Ok(*self.number(py))
  |                         ^^ help: a local variable with a similar name exists: `_py`
```

### After:

The original code builds cleanly.