### PR TITLE
Consistently refer to the right `Result` in macro expansion

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -78,7 +78,7 @@ macro_rules! py_exception {
             fn downcast_from<'p>(
                 py: $crate::Python<'p>,
                 obj: $crate::PyObject,
-            ) -> Result<$name, $crate::PythonObjectDowncastError<'p>> {
+            ) -> $crate::_detail::Result<$name, $crate::PythonObjectDowncastError<'p>> {
                 if <$name as $crate::PythonObjectWithTypeObject>::type_object(py)
                     .is_instance(py, &obj)
                 {
@@ -96,7 +96,7 @@ macro_rules! py_exception {
             fn downcast_borrow_from<'a, 'p>(
                 py: $crate::Python<'p>,
                 obj: &'a $crate::PyObject,
-            ) -> Result<&'a $name, $crate::PythonObjectDowncastError<'p>> {
+            ) -> $crate::_detail::Result<&'a $name, $crate::PythonObjectDowncastError<'p>> {
                 if <$name as $crate::PythonObjectWithTypeObject>::type_object(py)
                     .is_instance(py, obj)
                 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,6 +237,7 @@ pub mod _detail {
         PythonObjectCallbackConverter,
     };
     pub use paste;
+    pub use std::result::Result;
 }
 
 /// Expands to an `extern "C"` function that allows Python to load

--- a/src/objects/exc.rs
+++ b/src/objects/exc.rs
@@ -40,7 +40,7 @@ macro_rules! exc_type(
         impl PythonObjectWithCheckedDowncast for $name {
             #[inline]
             fn downcast_from<'p>(py: Python<'p>, obj : PyObject)
-                -> Result<$name, PythonObjectDowncastError<'p>>
+                -> $crate::_detail::Result<$name, PythonObjectDowncastError<'p>>
             {
                 unsafe {
                     if ffi::PyObject_TypeCheck(obj.as_ptr(), ffi::$exc_name as *mut ffi::PyTypeObject) != 0 {
@@ -57,7 +57,7 @@ macro_rules! exc_type(
 
             #[inline]
             fn downcast_borrow_from<'a, 'p>(py: Python<'p>, obj: &'a PyObject)
-                -> Result<&'a $name, PythonObjectDowncastError<'p>>
+                -> $crate::_detail::Result<&'a $name, PythonObjectDowncastError<'p>>
             {
                 unsafe {
                     if ffi::PyObject_TypeCheck(obj.as_ptr(), ffi::$exc_name as *mut ffi::PyTypeObject) != 0 {

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -80,7 +80,7 @@ macro_rules! pyobject_newtype(
 
         impl crate::python::PythonObjectWithCheckedDowncast for $name {
             #[inline]
-            fn downcast_from<'p>(py: crate::python::Python<'p>, obj: crate::objects::object::PyObject) -> Result<$name, crate::python::PythonObjectDowncastError<'p>> {
+            fn downcast_from<'p>(py: crate::python::Python<'p>, obj: crate::objects::object::PyObject) -> $crate::_detail::Result<$name, crate::python::PythonObjectDowncastError<'p>> {
                 unsafe {
                     if crate::ffi::$checkfunction(obj.as_ptr()) != 0 {
                         Ok($name(obj))
@@ -95,7 +95,7 @@ macro_rules! pyobject_newtype(
             }
 
             #[inline]
-            fn downcast_borrow_from<'a, 'p>(py: crate::python::Python<'p>, obj: &'a crate::objects::object::PyObject) -> Result<&'a $name, crate::python::PythonObjectDowncastError<'p>> {
+            fn downcast_borrow_from<'a, 'p>(py: crate::python::Python<'p>, obj: &'a crate::objects::object::PyObject) -> $crate::_detail::Result<&'a $name, crate::python::PythonObjectDowncastError<'p>> {
                 unsafe {
                     if crate::ffi::$checkfunction(obj.as_ptr()) != 0 {
                         Ok(std::mem::transmute(obj))

--- a/src/py_class/py_class_impl.py
+++ b/src/py_class/py_class_impl.py
@@ -83,7 +83,7 @@ base_case = '''
 
         impl $crate::PythonObjectWithCheckedDowncast for $class {
             #[inline]
-            fn downcast_from<'p>(py: $crate::Python<'p>, obj: $crate::PyObject) -> Result<$class, $crate::PythonObjectDowncastError<'p>> {
+            fn downcast_from<'p>(py: $crate::Python<'p>, obj: $crate::PyObject) -> $crate::_detail::Result<$class, $crate::PythonObjectDowncastError<'p>> {
                 if py.get_type::<$class>().is_instance(py, &obj) {
                     Ok($class { _unsafe_inner: obj })
                 } else {
@@ -96,7 +96,7 @@ base_case = '''
             }
 
             #[inline]
-            fn downcast_borrow_from<'a, 'p>(py: $crate::Python<'p>, obj: &'a $crate::PyObject) -> Result<&'a $class, $crate::PythonObjectDowncastError<'p>> {
+            fn downcast_borrow_from<'a, 'p>(py: $crate::Python<'p>, obj: &'a $crate::PyObject) -> $crate::_detail::Result<&'a $class, $crate::PythonObjectDowncastError<'p>> {
                 if py.get_type::<$class>().is_instance(py, obj) {
                     unsafe { Ok(std::mem::transmute(obj)) }
                 } else {
@@ -501,7 +501,7 @@ def traverse_and_clear():
                     fn __traverse__(&$slf,
                         $py: $crate::Python,
                         $visit: $crate::py_class::gc::VisitProc)
-                    -> Result<(), $crate::py_class::gc::TraverseError>
+                    -> $crate::_detail::Result<(), $crate::py_class::gc::TraverseError>
                     $body
                 }
             }

--- a/src/py_class/py_class_impl2.rs
+++ b/src/py_class/py_class_impl2.rs
@@ -78,7 +78,7 @@ macro_rules! py_class_impl {
 
         impl $crate::PythonObjectWithCheckedDowncast for $class {
             #[inline]
-            fn downcast_from<'p>(py: $crate::Python<'p>, obj: $crate::PyObject) -> Result<$class, $crate::PythonObjectDowncastError<'p>> {
+            fn downcast_from<'p>(py: $crate::Python<'p>, obj: $crate::PyObject) -> $crate::_detail::Result<$class, $crate::PythonObjectDowncastError<'p>> {
                 if py.get_type::<$class>().is_instance(py, &obj) {
                     Ok($class { _unsafe_inner: obj })
                 } else {
@@ -91,7 +91,7 @@ macro_rules! py_class_impl {
             }
 
             #[inline]
-            fn downcast_borrow_from<'a, 'p>(py: $crate::Python<'p>, obj: &'a $crate::PyObject) -> Result<&'a $class, $crate::PythonObjectDowncastError<'p>> {
+            fn downcast_borrow_from<'a, 'p>(py: $crate::Python<'p>, obj: &'a $crate::PyObject) -> $crate::_detail::Result<&'a $class, $crate::PythonObjectDowncastError<'p>> {
                 if py.get_type::<$class>().is_instance(py, obj) {
                     unsafe { Ok(std::mem::transmute(obj)) }
                 } else {
@@ -332,7 +332,7 @@ macro_rules! py_class_impl {
                     fn __traverse__(&$slf,
                     $py: $crate::Python,
                     $visit: $crate::py_class::gc::VisitProc)
-                    -> Result<(), $crate::py_class::gc::TraverseError>
+                    -> $crate::_detail::Result<(), $crate::py_class::gc::TraverseError>
                     $body
                 }
             }

--- a/src/py_class/py_class_impl3.rs
+++ b/src/py_class/py_class_impl3.rs
@@ -78,7 +78,7 @@ macro_rules! py_class_impl {
 
         impl $crate::PythonObjectWithCheckedDowncast for $class {
             #[inline]
-            fn downcast_from<'p>(py: $crate::Python<'p>, obj: $crate::PyObject) -> Result<$class, $crate::PythonObjectDowncastError<'p>> {
+            fn downcast_from<'p>(py: $crate::Python<'p>, obj: $crate::PyObject) -> $crate::_detail::Result<$class, $crate::PythonObjectDowncastError<'p>> {
                 if py.get_type::<$class>().is_instance(py, &obj) {
                     Ok($class { _unsafe_inner: obj })
                 } else {
@@ -91,7 +91,7 @@ macro_rules! py_class_impl {
             }
 
             #[inline]
-            fn downcast_borrow_from<'a, 'p>(py: $crate::Python<'p>, obj: &'a $crate::PyObject) -> Result<&'a $class, $crate::PythonObjectDowncastError<'p>> {
+            fn downcast_borrow_from<'a, 'p>(py: $crate::Python<'p>, obj: &'a $crate::PyObject) -> $crate::_detail::Result<&'a $class, $crate::PythonObjectDowncastError<'p>> {
                 if py.get_type::<$class>().is_instance(py, obj) {
                     unsafe { Ok(std::mem::transmute(obj)) }
                 } else {
@@ -332,7 +332,7 @@ macro_rules! py_class_impl {
                     fn __traverse__(&$slf,
                     $py: $crate::Python,
                     $visit: $crate::py_class::gc::VisitProc)
-                    -> Result<(), $crate::py_class::gc::TraverseError>
+                    -> $crate::_detail::Result<(), $crate::py_class::gc::TraverseError>
                     $body
                 }
             }


### PR DESCRIPTION
Without this, importing any other crate's `Result` type alias in a module that uses cpython's macros causes compilation to fail in a variety of interesting ways.

Repro:

```rust
use cpython::{py_class, PyResult};
use std::io::Result;

py_class!(class Struct |py| {
    def __new__(_cls) -> PyResult<Struct> {
        Struct::create_instance(py)
    }
});
```

The resulting diagnostic:

```console
error[E0107]: this type alias takes 1 generic argument but 2 generic arguments were supplied
  --> src/main.rs:4:1
   |
4  | / py_class!(class Struct |py| {
5  | |     def __new__(_cls) -> PyResult<Struct> {
6  | |         Struct::create_instance(py)
7  | |     }
8  | | });
   | |  ^
   | |  |
   | |__expected 1 generic argument
   |    help: remove this generic argument
   |
note: type alias defined here, with 1 generic parameter: `T`
  --> nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/io/error.rs:55:10
   |
55 | pub type Result<T> = result::Result<T, Error>;
   |          ^^^^^^ -
   = note: this error originates in the macro `$crate::py_class_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
```