### PR TITLE
Replace -Z ast-json in the check for undefined symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,10 @@ build: src/py_class/py_class_impl2.rs src/py_class/py_class_impl3.rs python27-sy
 
 test: build
 	cargo test $(CARGO_FLAGS)
+ifeq ($(NIGHTLY),1)
+# unpretty=ast-tree,expanded output is only supported on nightly
 	python$(PY) tests/check_symbols.py
+endif
 
 doc: build
 	cargo doc --no-deps $(CARGO_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,7 @@ build: src/py_class/py_class_impl2.rs src/py_class/py_class_impl3.rs python27-sy
 
 test: build
 	cargo test $(CARGO_FLAGS)
-ifeq ($(NIGHTLY),1)
-# ast-json output is only supported on nightly
 	python$(PY) tests/check_symbols.py
-endif
 
 doc: build
 	cargo doc --no-deps $(CARGO_FLAGS)

--- a/tests/check_symbols.py
+++ b/tests/check_symbols.py
@@ -57,14 +57,14 @@ for name in interesting_config_values:
     cfgs += ['--cfg', 'py_sys_config="{}_{}"'.format(name, sysconfig.get_config_var(name))]
 
 subprocess.call(cargo_cmd + ['--'] + cfgs)
-output = subprocess.check_output(['nm', '-C', '-u', '../target/debug/libpython{}_sys.rlib'.format(3 if sys.version_info.major == 3 else 27)])
+output = subprocess.check_output(['nm', '-C', '-g', '../target/debug/libpython{}_sys.rlib'.format(3 if sys.version_info.major == 3 else 27)])
 lines = output.decode('ascii').split('\n')
 foreign_symbols = set()
 
 for line in lines:
-    if ' U ' in line:
-        symb = line.split(' U ')[-1]
-        foreign_symbols.add(symb)
+    parts = line.split(' ')
+    if len(parts) > 1:
+        foreign_symbols.add(parts[-1])
 
 print(lines[:25])
 print(len(foreign_symbols))

--- a/tests/check_symbols.py
+++ b/tests/check_symbols.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import re
 import sysconfig
 import subprocess
 import os
@@ -56,20 +57,47 @@ interesting_config_values = ['Py_UNICODE_SIZE']
 for name in interesting_config_values:
     cfgs += ['--cfg', 'py_sys_config="{}_{}"'.format(name, sysconfig.get_config_var(name))]
 
-subprocess.call(cargo_cmd + ['--'] + cfgs)
-output = subprocess.check_output(['nm', '-C', '-g', '../target/debug/libpython{}_sys.rlib'.format(3 if sys.version_info.major == 3 else 27)])
-lines = output.decode('ascii').split('\n')
+
+def match_braces(text):
+    stack = []
+    locs = dict()
+    for i, c in enumerate(asttree):
+        if c == '{':
+            stack.append(i)
+        elif c == '}':
+            try:
+                locs[stack.pop()] = i
+            except IndexError:
+                break
+    return locs
+
+
+foreignsig = 'ForeignMod {'
+foreign_sections = []
 foreign_symbols = set()
 
-for line in lines:
-    parts = line.split(' ')
-    if len(parts) > 1:
-        foreign_symbols.add(parts[-1])
+output = subprocess.check_output(cargo_cmd + ['--', '-Z', 'unpretty=ast-tree,expanded'] + cfgs)
+asttree = output.decode('ascii')
+while asttree:
+    idx = asttree.find(foreignsig)
+    if idx < 0:
+        break
+    asttree = asttree[asttree.find(foreignsig):]
+    locs = match_braces(asttree)
+    if locs:
+        endpos = locs[len(foreignsig) - 1] + 1
+        foreign_sections.append(asttree[:endpos])
+        asttree = asttree[endpos:]
 
-print(lines[:25])
-print(len(foreign_symbols))
-assert 'PyList_Type' in foreign_symbols, "Failed getting statics from nm"
-assert 'PyList_New' in foreign_symbols, "Failed getting functions from nm"
+for section in foreign_sections:
+    lines = section.split('\n')
+    for idx in range(len(lines)):
+        line = lines[idx]
+        if ('kind: Fn(' in line) or ('kind: Static(' in line):
+            foreign_symbols.add(re.sub(r'\s*ident: (.*)#[0-9]*,', r'\1', lines[idx-1]))
+
+assert 'PyList_Type' in foreign_symbols, "Failed getting statics from rustc -Z unpretty=ast-tree,expanded"
+assert 'PyList_New' in foreign_symbols, "Failed getting functions from rustc -Z unpretty=ast-tree,expanded"
 
 names = sorted(foreign_symbols - so_symbols)
 if names:

--- a/tests/check_symbols.py
+++ b/tests/check_symbols.py
@@ -66,8 +66,10 @@ for line in lines:
         symb = line.split(' U ')[-1]
         foreign_symbols.add(symb)
 
-assert 'PyList_Type' in foreign_symbols, "Failed getting statics from rustc -Z unpretty=ast-tree,expanded"
-assert 'PyList_New' in foreign_symbols, "Failed getting functions from rustc -Z unpretty=ast-tree,expanded"
+print(lines[:25])
+print(len(foreign_symbols))
+assert 'PyList_Type' in foreign_symbols, "Failed getting statics from nm"
+assert 'PyList_New' in foreign_symbols, "Failed getting functions from nm"
 
 names = sorted(foreign_symbols - so_symbols)
 if names:


### PR DESCRIPTION
`-Z ast-json` ist no longer available in Rust nightly, see also https://github.com/dgrunwald/rust-cpython/pull/279#issuecomment-1159658662. Suggestion: Let `nm` report undefined symbols. This should also work for Rust stable.