### PR TITLE
Support applying unused_braces rustc suggestion in py_module_initializer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,7 @@ pub mod _detail {
 #[macro_export]
 #[cfg(feature = "python27-sys")]
 macro_rules! py_module_initializer {
-    ($name: ident, $( $_py2: ident, $_py3: ident, )? |$py_id: ident, $m_id: ident| $body: tt) => {
+    ($name: ident, $( $_py2: ident, $_py3: ident, )? |$py_id: ident, $m_id: ident| $body: expr) => {
         $crate::_detail::paste::item! {
             #[no_mangle]
             #[allow(non_snake_case)]
@@ -349,7 +349,7 @@ pub unsafe fn py_module_initializer_impl(
 #[macro_export]
 #[cfg(feature = "python3-sys")]
 macro_rules! py_module_initializer {
-    ($name: ident, $( $_py2: ident, $_py3: ident, )? |$py_id: ident, $m_id: ident| $body: tt) => {
+    ($name: ident, $( $_py2: ident, $_py3: ident, )? |$py_id: ident, $m_id: ident| $body: expr) => {
         $crate::_detail::paste::item! {
             #[no_mangle]
             #[allow(non_snake_case)]


### PR DESCRIPTION
Previously, if you wrote a `py_module_initializer!` invocation with braces around the body like this:

```rust
cpython::py_module_initializer!(cpython_minimal, |_py, _m| { Ok(()) });
```

then rustc would produce this `unused_braces` warning and suggestion:

```console
warning: unnecessary braces around block return value
 --> src/lib.rs:1:60
  |
1 | cpython::py_module_initializer!(cpython_minimal, |_py, _m| { Ok(()) });
  |                                                            ^^      ^^
  |
  = note: `#[warn(unused_braces)]` on by default
help: remove these braces
  |
1 - cpython::py_module_initializer!(cpython_minimal, |_py, _m| { Ok(()) });
1 + cpython::py_module_initializer!(cpython_minimal, |_py, _m| Ok(()));
  |
```

However, applying the suggestion would cause the macro invocation to fail to compile.

```console
error: no rules expected the token `(`
   --> src/lib.rs:1:62
    |
1   | cpython::py_module_initializer!(cpython_minimal, |_py, _m| Ok(()));
    |                                                              ^ no rules expected this token in macro call
    |
note: while trying to match meta-variable `$body:tt`
   --> $CARGO_HOME/registry/src/index.crates.io-6f17d22bba15001f/cpython-0.7.2/src/lib.rs:352:84
    |
352 |     ($name: ident, $( $_py2: ident, $_py3: ident, )? |$py_id: ident, $m_id: ident| $body: tt) => {
    |                                                                                    ^^^^^^^^^
```

This PR makes `py_module_initializer!` accept body expressions without the brace.